### PR TITLE
support link_model on link attributes

### DIFF
--- a/db/migrations/038_add_reference_patient.rb
+++ b/db/migrations/038_add_reference_patient.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:patients) do
+      add_foreign_key :reference_patient_id, :patients
+    end
+  end
+end

--- a/gem/lib/magma/attribute.rb
+++ b/gem/lib/magma/attribute.rb
@@ -3,7 +3,9 @@ class Magma
     def self.options
       [ :type, :desc, :display_name, 
         :hide, :readonly, :unique, 
-        :match, :format_hint, :loader ]
+        :match, :format_hint, :loader,
+        :link_model
+      ]
     end
     DISPLAY_ONLY = [ :child, :collection ]
     attr_reader :name, :type, :desc, :loader
@@ -17,6 +19,7 @@ class Magma
     def json_template
       {
         name: @name,
+        model_name: @link_model || @name,
         type: @type.nil? ? @type : @type.name,
         attribute_class: self.class.name,
         desc: @desc,

--- a/gem/lib/magma/attributes/link.rb
+++ b/gem/lib/magma/attributes/link.rb
@@ -1,7 +1,7 @@
 class Magma
   module Link
     def link_model
-      Magma.instance.get_model(@name)
+      Magma.instance.get_model(@link_model || @name)
     end
 
     def foreign_id

--- a/gem/lib/magma/model.rb
+++ b/gem/lib/magma/model.rb
@@ -43,7 +43,7 @@ class Magma
       end
 
       def link name, opts = {}
-        many_to_one name, :polymorphic => opts[:column_type]
+        many_to_one name, class: (opts[:link_model] || name).to_s.camel_case.to_sym
         attribute name, opts.merge(attribute_class: Magma::ForeignKeyAttribute)
       end
 

--- a/gem/lib/models/patient.rb
+++ b/gem/lib/models/patient.rb
@@ -52,6 +52,8 @@ class Patient < Magma::Model
     loader: :flowjo_xml_loader,
     desc: "WSP file from Flojo 10 containing all four stains for each sample for this patient."
 
+  link :reference_patient, link_model: :patient
+
   attribute :stain_version,
     type: String,
     desc: "Version of the stain panel used for processing."


### PR DESCRIPTION
This adds link_model to attributes, which allows you to set a model name other than the column name for a given attribute (e.g. the attribute 'physician' can have model 'doctor' instead of defaulting to model 'physician')