### PR TITLE
don't eager load tables if collapse_tables is true

### DIFF
--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -25,8 +25,7 @@ class Magma
     def txt_for record
       nil
     end
-    # since a table has to display the other model, we should eager load its
-    # column dependencies
+
     def eager
       @name
     end

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -214,18 +214,5 @@ class Magma
     def txt_for att_name
       model.attributes[att_name].txt_for(self)
     end
-
-    def assoc_records att_names = nil
-      att_names ||= model.attributes.keys
-      Hash[
-        att_names.map do |name|
-          att = model.attributes[name]
-          next unless att.is_a? Magma::TableAttribute
-          [
-            att.link_model, self.send(name)
-          ]
-        end.compact
-      ]
-    end
   end
 end

--- a/lib/magma/payload.rb
+++ b/lib/magma/payload.rb
@@ -15,20 +15,10 @@ class Magma
       return if @models[model]
 
       @models[model] = ModelPayload.new(model,attribute_names)
-
-      model.assoc_models(attribute_names).each do |assoc_model|
-        @models[assoc_model] = ModelPayload.new(assoc_model,nil)
-      end
     end
     
     def add_records model, records
       @models[model].add_records records
-
-      records.each do |record|
-        record.assoc_records(@models[model].attribute_names).each do |assoc_model,assoc_records|
-          @models[assoc_model].add_records assoc_records
-        end
-      end
     end
 
     def add_revision revision


### PR DESCRIPTION
This is a small improvement to the retrieve endpoint which makes it not use eager loading for tables if the 'collapse_tables' option is specified (and makes that option mandatory for tsv format), useful for just grabbing one table. The other mode is used in the 'browse' window to grab an associated table (e.g. i am on a rna_seq page and want to list gene_exp for that record)