### PR TITLE
Graft improve predicate interface

### DIFF
--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -23,7 +23,7 @@ class Magma
 
     def json_for record
       link = record[@name]
-      link ? link.map(&:last) : nil
+      link ? link.map(&:last).sort : nil
     end
 
     def txt_for record

--- a/lib/magma/query/constraint.rb
+++ b/lib/magma/query/constraint.rb
@@ -1,0 +1,25 @@
+class Magma
+  class Constraint
+    attr_reader :conditions
+
+    def initialize(*args)
+      @conditions = args
+    end
+
+    def apply(query)
+      query.where(*@conditions)
+    end
+
+    def to_s
+      @conditions.to_s
+    end
+
+    def hash
+      @conditions.hash
+    end
+
+    def eql?(other)
+      @conditions == other.conditions
+    end
+  end
+end

--- a/lib/magma/query/constraint.rb
+++ b/lib/magma/query/constraint.rb
@@ -7,7 +7,14 @@ class Magma
     end
 
     def apply(query)
-      query.where(*@conditions)
+      @inverted ?
+        query.exclude(*@conditions)
+      :
+        query.where(*@conditions)
+    end
+
+    def invert!
+      @inverted = true
     end
 
     def to_s

--- a/lib/magma/query/join.rb
+++ b/lib/magma/query/join.rb
@@ -1,0 +1,38 @@
+class Magma
+  class Join
+    def initialize(t1, t1_alias, t1_id, t2, t2_alias, t2_id)
+      @table1 = t1
+      @table1_alias = t1_alias.to_sym
+      @table1_id = t1_id.to_sym
+      @table2_alias = t2_alias.to_sym
+      @table2_id = t2_id.to_sym
+    end
+
+    def apply query
+      query.left_outer_join(
+        Sequel.as(@table1,@table1_alias),
+        table1_column => table2_column
+      )
+    end
+
+    def to_s
+      {table1_column=> table2_column}.to_s
+    end
+
+    def table1_column
+      Sequel.qualify(@table1_alias, @table1_id)
+    end
+
+    def table2_column
+      Sequel.qualify(@table2_alias, @table2_id)
+    end
+
+    def hash
+      table1_column.hash + table2_column.hash
+    end
+
+    def eql?(other)
+      table1_column == other.table1_column && table2_column == other.table2_column
+    end
+  end
+end

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -1,29 +1,32 @@
 # This is the base class for parsing a query (Question). Each argument in the
 # question is a series of arguments which yield Predicates, starting with a
-# ModelPredicate and ending with a TerminalPredicate. Each predicate
-# determines what are the correct following arguments and validates
-# accordingly.
+# ModelPredicate and ending with a TerminalPredicate. Each predicate determines
+# what are the correct following arguments and validates accordingly.
 #
 # There are four basic types of predicates:
 #
 # ModelPredicate   - represents a list of records, its arguments are a series
-#                    of filters on that list and various options to reduce
-#                    that list.
+# of filters on that list and various options to reduce that list.
 # RecordPredicate  - represents a single record, its arguments are mostly a
-#                    list of attribute names
-# ColumnPredicate  - represents a value from a database table, its
-#                    arguments are boolean tests on that value
-# VectorPredicate  - represents an array of mapped values
+# list of attribute names ColumnPredicate  - represents a value from a database
+# table, its arguments are boolean tests on that value VectorPredicate  -
+# represents an array of mapped values
 # 
-# From these predicates we wish to produce a SQL query. The basic form of
-# such a query is defined by SELECT, FROM+JOIN, WHERE. Each predicate must
-# therefore respond to #select, #join, #constraint. The Question will
-# collect these and use them to make the SQL query.
+# From these predicates we wish to produce a SQL query. The basic form of such
+# a query is defined by SELECT, FROM+JOIN, WHERE. Each predicate must therefore
+# respond to #select, #join, #constraint. The Question will collect these and
+# use them to make the SQL query.
 #
 # Each predicate consumes arguments from the argument chain until it is
-# satisfied, and then returns a valid child predicate which is responsible
-# for the rest. If a predicate does not know how to consume its arguments,
-# it raises an error.
+# satisfied, and then returns a valid child predicate which is responsible for
+# the rest. If a predicate does not know how to consume its arguments, it
+# raises an error.
+#
+# Finally, each predicate will be handed the table of results from the SQL
+# query. The columns in this table will be aliased so each predicate can
+# recognize its relevant targets. Each predicate recursively hands down the
+# table (or subsets of it) to its children through the #extract method, the
+# final result of which will be a mapped value of some sort.
 
 class Magma
   class Predicate
@@ -42,11 +45,19 @@ class Magma
     end
 
     def join
-      []
+      if @verb.gives?(:join)
+        [ @verb.do(:join) ]
+      else
+        []
+      end
     end
 
     def constraint
-      []
+      if @verb.gives?(:constraint)
+        [ @verb.do(:constraint) ]
+      else
+        []
+      end
     end
 
     def select
@@ -54,6 +65,14 @@ class Magma
     end
 
     def extract table, identity
+      if @verb.gives?(:extract)
+        @verb.do(:extract, table, identity)
+      else
+        child_extract(table,identity)
+      end
+    end
+
+    def child_extract table, identity
       @child_predicate.is_a?(Predicate) ? @child_predicate.extract(table, identity) : table
     end
 
@@ -87,18 +106,87 @@ class Magma
 
     private
 
+    # This function takes the argument list and matches it to one of the
+    # defined verbs for this predicate. If none exist, it raises an
+    # error. If one exists, it sets @arguments, @query_args and @child_predicate
+    def process_args(query_args)
+      @verb, @arguments, @query_args = self.class.match_verbs(query_args, self)
+
+      @child_predicate = @verb.do(:child)
+    end
+
+    def self.verb *args, &block
+      @verbs ||= {}
+      @verbs[args] = block
+    end
+
+    def self.match_verbs(query_args, predicate)
+      @verbs ||= {}
+      matching_args, matching_block = @verbs.find do |verb_args, block|
+        verb_args.each.with_index.all? do |verb_arg, i|
+          query_arg = query_args[i]
+          case verb_arg
+          when nil
+            query_arg.nil?
+          when Class
+            query_arg.is_a?(verb_arg)
+          when Array
+            verb_arg.include?(query_arg)
+          when Symbol
+            predicate.send(verb_arg, query_arg)
+          when String
+            verb_arg == query_arg
+          end
+        end
+      end
+      return [
+        Magma::Verb.new(predicate,matching_block),
+        query_args[0...matching_args.size],
+        query_args[matching_args.size..-1]
+      ]
+    end
+
+    # Some constraint helpers
+    def comparison_constraint column_name, operator, value
+      new(
+        Sequel.lit(
+          "? #{operator.sub(/::/,'')} ?",
+          Sequel.qualify(alias_name, column_name),
+          value
+        )
+      )
+    end
+
+    def not_null_constraint(column_name)
+      new(
+        Sequel.lit(
+          "? IS NOT NULL",
+          Sequel.qualify(alias_name, column_name)
+        )
+      )
+    end
+
+    def basic_constraint column_name, value
+      new(
+        Sequel.lit(
+          Sequel.qualify(alias_name, column_name) => value
+        )
+      )
+    end
+
     def invalid_argument! argument
       raise ArgumentError, "Expected an argument to #{self.class.name}" if argument.nil?
       raise ArgumentError, "#{argument} is not a valid argument to #{self.class.name}"
     end
 
     def terminal value
-      raise ArgumentError, "Trailing arguments after terminal value!" unless @predicates.empty?
+      raise ArgumentError, "Trailing arguments after terminal value!" unless @query_args.empty?
       Magma::TerminalPredicate.new(value)
     end
   end
 end
 
+require_relative 'verb'
 require_relative 'predicate/model'
 require_relative 'predicate/record'
 require_relative 'predicate/column'

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -6,11 +6,13 @@
 # There are four basic types of predicates:
 #
 # ModelPredicate   - represents a list of records, its arguments are a series
-# of filters on that list and various options to reduce that list.
+#                    of filters on that list and various options to reduce that
+#                    list.
 # RecordPredicate  - represents a single record, its arguments are mostly a
-# list of attribute names ColumnPredicate  - represents a value from a database
-# table, its arguments are boolean tests on that value VectorPredicate  -
-# represents an array of mapped values
+#                    list of attribute names 
+# ColumnPredicate  - represents a value from a database table, its arguments
+#                    are boolean tests on that value
+# VectorPredicate  - represents an array of mapped values
 # 
 # From these predicates we wish to produce a SQL query. The basic form of such
 # a query is defined by SELECT, FROM+JOIN, WHERE. Each predicate must therefore

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -167,6 +167,14 @@ class Magma
       )
     end
 
+    def not_constraint column_name, value
+      Magma::Constraint.new(
+        Sequel.qualify(alias_name, column_name) => value
+      ).tap do |constraint|
+        constraint.invert!
+      end
+    end
+
     def basic_constraint column_name, value
       Magma::Constraint.new(
         Sequel.qualify(alias_name, column_name) => value

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -1,11 +1,32 @@
 # This is the base class for parsing a query (Question). Each argument in the
-# question is a Predicate, starting with a ModelPredicate and ending with a
-# TerminalPredicate. Each predicate determines what are the correct following
-# arguments and validates accordingly.
+# question is a series of arguments which yield Predicates, starting with a
+# ModelPredicate and ending with a TerminalPredicate. Each predicate
+# determines what are the correct following arguments and validates
+# accordingly.
+#
+# There are four basic types of predicates:
+#
+# ModelPredicate   - represents a list of records, its arguments are a series
+#                    of filters on that list and various options to reduce
+#                    that list.
+# RecordPredicate  - represents a single record, its arguments are mostly a
+#                    list of attribute names
+# ColumnPredicate  - represents a value from a database table, its
+#                    arguments are boolean tests on that value
+# VectorPredicate  - represents an array of mapped values
+# 
+# From these predicates we wish to produce a SQL query. The basic form of
+# such a query is defined by SELECT, FROM+JOIN, WHERE. Each predicate must
+# therefore respond to #select, #join, #constraint. The Question will
+# collect these and use them to make the SQL query.
+#
+# Each predicate consumes arguments from the argument chain until it is
+# satisfied, and then returns a valid child predicate which is responsible
+# for the rest. If a predicate does not know how to consume its arguments,
+# it raises an error.
 
 class Magma
   class Predicate
-
     attr_reader :argument
 
     def reduced_type

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -45,16 +45,16 @@ class Magma
     end
 
     def join
-      if @verb.gives?(:join)
-        [ @verb.do(:join) ]
+      if @verb && @verb.gives?(:join)
+        [ @verb.do(:join) ].compact
       else
         []
       end
     end
 
     def constraint
-      if @verb.gives?(:constraint)
-        [ @verb.do(:constraint) ]
+      if @verb && @verb.gives?(:constraint)
+        [ @verb.do(:constraint) ].compact
       else
         []
       end
@@ -65,7 +65,7 @@ class Magma
     end
 
     def extract table, identity
-      if @verb.gives?(:extract)
+      if @verb && @verb.gives?(:extract)
         @verb.do(:extract, table, identity)
       else
         child_extract(table,identity)
@@ -139,16 +139,17 @@ class Magma
           end
         end
       end
+
       return [
         Magma::Verb.new(predicate,matching_block),
         query_args[0...matching_args.size],
-        query_args[matching_args.size..-1]
+        query_args[matching_args.size..-1] || []
       ]
     end
 
     # Some constraint helpers
     def comparison_constraint column_name, operator, value
-      new(
+      Magma::Constraint.new(
         Sequel.lit(
           "? #{operator.sub(/::/,'')} ?",
           Sequel.qualify(alias_name, column_name),
@@ -158,7 +159,7 @@ class Magma
     end
 
     def not_null_constraint(column_name)
-      new(
+      Magma::Constraint.new(
         Sequel.lit(
           "? IS NOT NULL",
           Sequel.qualify(alias_name, column_name)
@@ -167,10 +168,8 @@ class Magma
     end
 
     def basic_constraint column_name, value
-      new(
-        Sequel.lit(
-          Sequel.qualify(alias_name, column_name) => value
-        )
+      Magma::Constraint.new(
+        Sequel.qualify(alias_name, column_name) => value
       )
     end
 

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -190,7 +190,7 @@ class Magma
     def not_null_constraint(column_name)
       Magma::Constraint.new(
         Sequel.lit(
-          "? IS NOT NULL",
+          '? IS NOT NULL',
           Sequel.qualify(alias_name, column_name)
         )
       )
@@ -216,7 +216,7 @@ class Magma
     end
 
     def terminal value
-      raise ArgumentError, "Trailing arguments after terminal value!" unless @query_args.empty?
+      raise ArgumentError, 'Trailing arguments after terminal value!' unless @query_args.empty?
       Magma::TerminalPredicate.new(value)
     end
   end

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -167,14 +167,23 @@ class Magma
           predicates: Hash[
             real_predicate_classes.map do |pred_class|
               [
-                pred_class.name.snake_case.sub(/^magma::/,'').sub(/_predicate/,''),
-                pred_class.verbs.keys
+                pred_class.predicate_name,
+                pred_class.verbs.map do |args, block|
+                  {
+                    args: args,
+                    return_type: Magma::Verb.new(nil,block).return_type
+                  }
+                end
               ]
             end
           ]
         }
 
         response.to_json
+      end
+
+      def predicate_name
+        name.snake_case.sub(/^magma::/,'').sub(/_predicate/,'')
       end
     end
 

--- a/lib/magma/query/predicate/boolean.rb
+++ b/lib/magma/query/predicate/boolean.rb
@@ -1,39 +1,27 @@
 class Magma
   class BooleanPredicate < Magma::ColumnPredicate
-    def constraint
-      case @argument
-      when "::true"
-        return [
-          Magma::Constraint.new(
-            Sequel.lit(
-              Sequel.qualify(alias_name, @attribute_name) => true
-            )
-          )
-        ]
-      when "::false"
-        return [
-          Magma::Constraint.new(
-            Sequel.lit(
-              Sequel.qualify(alias_name, @attribute_name) => false
-            )
-          )
-        ]
-      end
-      super
+    verb nil do
+      child TrueClass
     end
 
-    private
+    verb "::true" do
+      child TrueClass
+      constraint do
+        Magma::Constraint.basic(true)
+      end
+    end
 
-    def get_child
-      case @argument
-      when "::true"
-      when "::false"
-      when "::null"
-        return terminal(TrueClass)
-      when nil
-        return terminal(TrueClass)
-      else
-        invalid_argument! @argument
+    verb "::false" do
+      child TrueClass
+      constraint do
+        Magma::Constraint.basic(false)
+      end
+    end
+
+    verb "::null" do
+      child TrueClass
+      constraint do
+        Magma::Constraint.basic(nil)
       end
     end
   end

--- a/lib/magma/query/predicate/boolean.rb
+++ b/lib/magma/query/predicate/boolean.rb
@@ -4,21 +4,21 @@ class Magma
       child TrueClass
     end
 
-    verb "::true" do
+    verb '::true' do
       child TrueClass
       constraint do
         Magma::Constraint.basic(true)
       end
     end
 
-    verb "::false" do
+    verb '::false' do
       child TrueClass
       constraint do
         Magma::Constraint.basic(false)
       end
     end
 
-    verb "::null" do
+    verb '::null' do
       child TrueClass
       constraint do
         Magma::Constraint.basic(nil)

--- a/lib/magma/query/predicate/boolean.rb
+++ b/lib/magma/query/predicate/boolean.rb
@@ -4,7 +4,7 @@ class Magma
       case @argument
       when "::true"
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.lit(
               Sequel.qualify(alias_name, @attribute_name) => true
             )
@@ -12,7 +12,7 @@ class Magma
         ]
       when "::false"
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.lit(
               Sequel.qualify(alias_name, @attribute_name) => false
             )

--- a/lib/magma/query/predicate/boolean.rb
+++ b/lib/magma/query/predicate/boolean.rb
@@ -7,21 +7,14 @@ class Magma
     verb '::true' do
       child TrueClass
       constraint do
-        Magma::Constraint.basic(true)
+        basic_constraint(@attribute_name, true)
       end
     end
 
     verb '::false' do
       child TrueClass
       constraint do
-        Magma::Constraint.basic(false)
-      end
-    end
-
-    verb '::null' do
-      child TrueClass
-      constraint do
-        Magma::Constraint.basic(nil)
+        basic_constraint(@attribute_name, false)
       end
     end
   end

--- a/lib/magma/query/predicate/column.rb
+++ b/lib/magma/query/predicate/column.rb
@@ -2,13 +2,11 @@ class Magma
   class ColumnPredicate < Magma::Predicate
     # This Predicate returns an actual attribute value of some kind - a number, integer, etc.,
     # or else a test on that value (number > 2, etc.)
-    def initialize model, alias_name, attribute_name, argument=nil, *query_args
+    def initialize model, alias_name, attribute_name, *query_args
       @model = model
       @alias_name = alias_name
       @attribute_name = attribute_name
-      @argument = argument
-      @query_args = query_args
-      @child_predicate = get_child
+      process_args(query_args)
     end
 
     def extract table, identity
@@ -16,7 +14,7 @@ class Magma
     end
 
     def select
-      @argument.nil? ? [ Sequel[alias_name][@attribute_name].as(column_name) ] : []
+      @arguments.empty? ? [ Sequel[alias_name][@attribute_name].as(column_name) ] : []
     end
 
     protected

--- a/lib/magma/query/predicate/column.rb
+++ b/lib/magma/query/predicate/column.rb
@@ -2,12 +2,12 @@ class Magma
   class ColumnPredicate < Magma::Predicate
     # This Predicate returns an actual attribute value of some kind - a number, integer, etc.,
     # or else a test on that value (number > 2, etc.)
-    def initialize model, alias_name, attribute_name, argument=nil, *predicates
+    def initialize model, alias_name, attribute_name, argument=nil, *query_args
       @model = model
       @alias_name = alias_name
       @attribute_name = attribute_name
       @argument = argument
-      @predicates = predicates
+      @query_args = query_args
       @child_predicate = get_child
     end
 

--- a/lib/magma/query/predicate/date_time.rb
+++ b/lib/magma/query/predicate/date_time.rb
@@ -21,7 +21,7 @@ class Magma
     def get_child
       case @argument
       when "::<=", "::<", "::>", "::>=", "::="
-        operand = @predicates.shift
+        operand = @query_args.shift
         invalid_argument! operand unless operand && operand.is_a?(String)
         @operand = DateTime.parse(operand)
         return terminal(TrueClass)

--- a/lib/magma/query/predicate/date_time.rb
+++ b/lib/magma/query/predicate/date_time.rb
@@ -4,7 +4,7 @@ class Magma
       case @argument
       when "::<=", "::<", "::>", "::>=", "::="
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.lit(
               "? #{@argument.sub(/::/,'')} ?",
               Sequel.qualify(alias_name, @attribute_name),

--- a/lib/magma/query/predicate/date_time.rb
+++ b/lib/magma/query/predicate/date_time.rb
@@ -4,7 +4,7 @@ class Magma
       child DateTime
     end
 
-    verb [ "::<=", "::<", "::>=", "::>", "::=" ], String do
+    verb [ '::<=', '::<', '::>=', '::>', '::=', '::!=' ], String do
       child TrueClass
 
       constraint do

--- a/lib/magma/query/predicate/date_time.rb
+++ b/lib/magma/query/predicate/date_time.rb
@@ -1,34 +1,14 @@
 class Magma
   class DateTimePredicate < Magma::ColumnPredicate
-    def constraint
-      case @argument
-      when "::<=", "::<", "::>", "::>=", "::="
-        return [
-          Magma::Constraint.new(
-            Sequel.lit(
-              "? #{@argument.sub(/::/,'')} ?",
-              Sequel.qualify(alias_name, @attribute_name),
-              @operand
-            )
-          )
-        ]
-      end
-      super
+    verb nil do
+      child DateTime
     end
 
-    private
+    verb [ "::<=", "::<", "::>=", "::>", "::=" ], String do
+      child TrueClass
 
-    def get_child
-      case @argument
-      when "::<=", "::<", "::>", "::>=", "::="
-        operand = @query_args.shift
-        invalid_argument! operand unless operand && operand.is_a?(String)
-        @operand = DateTime.parse(operand)
-        return terminal(TrueClass)
-      when nil
-        return terminal(DateTime)
-      else
-        invalid_argument! @argument
+      constraint do
+        comparison_constraint(@attribute_name, @arguments[0], DateTime.parse(@arguments[1]))
       end
     end
   end

--- a/lib/magma/query/predicate/file.rb
+++ b/lib/magma/query/predicate/file.rb
@@ -1,10 +1,10 @@
 class Magma
   class FilePredicate < Magma::ColumnPredicate
-    verb "::url" do
+    verb '::url' do
       child String
     end
 
-    verb "::path" do
+    verb '::path' do
       child String
     end
 

--- a/lib/magma/query/predicate/file.rb
+++ b/lib/magma/query/predicate/file.rb
@@ -1,21 +1,15 @@
 class Magma
   class FilePredicate < Magma::ColumnPredicate
+    verb "::url" do
+      child String
+    end
+
+    verb "::path" do
+      child String
+    end
 
     def select
       [ Sequel[alias_name][@attribute_name].as(column_name) ]
-    end
-
-    private
-
-    def get_child
-      case @argument
-      when "::url"
-        return terminal(String)
-      when "::path"
-        return terminal(String)
-      else
-        invalid_argument! @argument
-      end
     end
   end
 end

--- a/lib/magma/query/predicate/metrics.rb
+++ b/lib/magma/query/predicate/metrics.rb
@@ -3,8 +3,11 @@ class Magma
     def initialize model, alias_name, *query_args
       @model = model
       @alias_name = alias_name
-      @query_args = query_args
-      @child_predicate = get_child
+      process_args(query_args)
+    end
+
+    verb nil do
+      child Hash
     end
 
     def extract table, identity
@@ -30,14 +33,10 @@ class Magma
     end
 
     def select
-      @argument.nil? ? [ Sequel[alias_name][@model.identity].as(column_name) ] : []
+      @arguments.empty? ? [ Sequel[alias_name][@model.identity].as(column_name) ] : []
     end
 
     private
-
-    def get_child
-      terminal(Hash)
-    end
 
     def column_name
       :"#{alias_name}_#{@model.identity}"

--- a/lib/magma/query/predicate/metrics.rb
+++ b/lib/magma/query/predicate/metrics.rb
@@ -1,9 +1,9 @@
 class Magma
   class MetricsPredicate < Magma::Predicate
-    def initialize model, alias_name, *predicates
+    def initialize model, alias_name, *query_args
       @model = model
       @alias_name = alias_name
-      @predicates = predicates
+      @query_args = query_args
       @child_predicate = get_child
     end
 

--- a/lib/magma/query/predicate/model.rb
+++ b/lib/magma/query/predicate/model.rb
@@ -26,16 +26,16 @@ class Magma
 
     attr_reader :model
 
-    def initialize(model, *predicates)
+    def initialize(model, *query_args)
       @model = model
       @filters = []
 
-      # Since we are shifting off the the first elements on the predicates array
+      # Since we are shifting off the the first elements on the query_args array
       # we look to see if the first element is an array itself. If it is then we
       # add it to the filters.
-      while predicates.first.is_a?(Array)
+      while query_args.first.is_a?(Array)
 
-        filter = RecordPredicate.new(@model, alias_name, *predicates.shift)
+        filter = RecordPredicate.new(@model, alias_name, *query_args.shift)
 
         err_msg = "Filter #{filter} does not reduce to Boolean "
         err_msg += "#{filter.argument} #{filter.reduced_type}!"
@@ -44,7 +44,7 @@ class Magma
         @filters.push(filter)
       end
 
-      @predicates = predicates
+      @query_args = query_args
       @child_predicate = get_child
     end
 

--- a/lib/magma/query/predicate/model.rb
+++ b/lib/magma/query/predicate/model.rb
@@ -69,6 +69,24 @@ class Magma
       end
     end
 
+    verb "::any" do
+      child TrueClass
+      extract do |table,return_identity|
+        table.any? do |row|
+          row[identity]
+        end
+      end
+    end
+
+    verb "::count" do
+      child Numeric
+      extract do |table,return_identity|
+        table.count do |row|
+          row[identity]
+        end
+      end
+    end
+
     def record_child
       RecordPredicate.new(@model, alias_name, *@query_args)
     end

--- a/lib/magma/query/predicate/model.rb
+++ b/lib/magma/query/predicate/model.rb
@@ -48,7 +48,7 @@ class Magma
 
     verb "::first" do
       child :record_child
-      extract do |table,identity|
+      extract do |table,return_identity|
         child_extract(
           table.group_by do |row|
             row[identity]
@@ -60,7 +60,7 @@ class Magma
 
     verb "::all" do
       child :record_child
-      extract do |table,identity|
+      extract do |table,return_identity|
         table.group_by do |row|
           row[identity]
         end.map do |identifier,rows|

--- a/lib/magma/query/predicate/model.rb
+++ b/lib/magma/query/predicate/model.rb
@@ -64,8 +64,9 @@ class Magma
         table.group_by do |row|
           row[identity]
         end.map do |identifier,rows|
+          next unless identifier
           [ identifier, child_extract(rows, identity) ]
-        end
+        end.compact
       end
     end
 

--- a/lib/magma/query/predicate/model.rb
+++ b/lib/magma/query/predicate/model.rb
@@ -46,7 +46,7 @@ class Magma
       process_args(query_args)
     end
 
-    verb "::first" do
+    verb '::first' do
       child :record_child
       extract do |table,return_identity|
         child_extract(
@@ -58,7 +58,7 @@ class Magma
       end
     end
 
-    verb "::all" do
+    verb '::all' do
       child :record_child
       extract do |table,return_identity|
         table.group_by do |row|
@@ -69,7 +69,7 @@ class Magma
       end
     end
 
-    verb "::any" do
+    verb '::any' do
       child TrueClass
       extract do |table,return_identity|
         table.any? do |row|
@@ -78,7 +78,7 @@ class Magma
       end
     end
 
-    verb "::count" do
+    verb '::count' do
       child Numeric
       extract do |table,return_identity|
         table.count do |row|

--- a/lib/magma/query/predicate/number.rb
+++ b/lib/magma/query/predicate/number.rb
@@ -27,12 +27,12 @@ class Magma
     def get_child
       case @argument
       when "::<=", "::<", "::>", "::>=", "::="
-        operand = @predicates.shift
+        operand = @query_args.shift
         invalid_argument! operand unless operand.respond_to? :to_f
         @operand = operand.to_f
         return terminal(TrueClass)
       when "::in"
-        @operand = @predicates.shift
+        @operand = @query_args.shift
         invalid_argument! @operand unless @operand && @operand.is_a?(Array)
         return terminal(TrueClass)
       when nil

--- a/lib/magma/query/predicate/number.rb
+++ b/lib/magma/query/predicate/number.rb
@@ -1,44 +1,21 @@
 class Magma
   class NumberPredicate < Magma::ColumnPredicate
-    def constraint 
-      case @argument
-      when "::<=", "::<", "::>", "::>=", "::="
-        return [
-          Magma::Constraint.new(
-            Sequel.lit(
-              "? #{@argument.sub(/::/,'')} ?",
-              Sequel.qualify(alias_name, @attribute_name),
-              @operand
-            )
-          )
-        ]
-      when "::in"
-        return [
-          Magma::Constraint.new(
-            Sequel.qualify(alias_name, @attribute_name) => @operand
-          )
-        ]
-      end
-      super
+    verb nil do
+      child Numeric
     end
 
-    private
+    verb [ "::<=", "::<", "::>=", "::>", "::=" ], Numeric do
+      child TrueClass
 
-    def get_child
-      case @argument
-      when "::<=", "::<", "::>", "::>=", "::="
-        operand = @query_args.shift
-        invalid_argument! operand unless operand.respond_to? :to_f
-        @operand = operand.to_f
-        return terminal(TrueClass)
-      when "::in"
-        @operand = @query_args.shift
-        invalid_argument! @operand unless @operand && @operand.is_a?(Array)
-        return terminal(TrueClass)
-      when nil
-        return terminal(Numeric)
-      else
-        invalid_argument! @argument
+      constraint do
+        comparison_constraint(@attribute_name, @arguments[0], @arguments[1].to_f)
+      end
+    end
+
+    verb "::in", Array do
+      child TrueClass
+      constraint do
+        basic_constraint(@attribute_name, @arguments[1])
       end
     end
   end

--- a/lib/magma/query/predicate/number.rb
+++ b/lib/magma/query/predicate/number.rb
@@ -4,7 +4,7 @@ class Magma
       child Numeric
     end
 
-    verb [ "::<=", "::<", "::>=", "::>", "::=" ], Numeric do
+    verb [ '::<=', '::<', '::>=', '::>', '::=', '::!=' ], Numeric do
       child TrueClass
 
       constraint do
@@ -12,10 +12,17 @@ class Magma
       end
     end
 
-    verb "::in", Array do
+    verb '::in', Array do
       child TrueClass
       constraint do
         basic_constraint(@attribute_name, @arguments[1])
+      end
+    end
+
+    verb '::not', Array do
+      child TrueClass
+      constraint do
+        not_constraint(@attribute_name, @arguments[1])
       end
     end
   end

--- a/lib/magma/query/predicate/number.rb
+++ b/lib/magma/query/predicate/number.rb
@@ -4,7 +4,7 @@ class Magma
       case @argument
       when "::<=", "::<", "::>", "::>=", "::="
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.lit(
               "? #{@argument.sub(/::/,'')} ?",
               Sequel.qualify(alias_name, @attribute_name),
@@ -14,7 +14,7 @@ class Magma
         ]
       when "::in"
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.qualify(alias_name, @attribute_name) => @operand
           )
         ]

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -18,11 +18,11 @@ class Magma
   #   3) ::identifier
     attr_reader :model
 
-    def initialize model, alias_name, argument, *predicates
+    def initialize model, alias_name, argument, *query_args
       @model = model
       @alias_name = alias_name
       @argument = argument
-      @predicates = predicates
+      @query_args = query_args
       @child_predicate = get_child
     end
 
@@ -87,13 +87,13 @@ class Magma
 
     def get_child
       if @argument == "::has"
-        attribute_name = @predicates.shift
+        attribute_name = @query_args.shift
         @attribute = validate_attribute(attribute_name)
         return terminal(TrueClass)
       elsif @argument == "::metrics"
-        return Magma::MetricsPredicate.new(@model, alias_name, *@predicates)
+        return Magma::MetricsPredicate.new(@model, alias_name, *@query_args)
       elsif @argument.is_a?(Array)
-        return Magma::VectorPredicate.new(@model, alias_name, @argument, *@predicates)
+        return Magma::VectorPredicate.new(@model, alias_name, @argument, *@query_args)
       else
         attribute_name = @argument == "::identifier" ? @model.identity : @argument
         @attribute = validate_attribute(attribute_name)
@@ -104,23 +104,23 @@ class Magma
     def get_attribute_child
       case @attribute
       when :id
-        return Magma::NumberPredicate.new(@model, alias_name, @attribute, *@predicates)
+        return Magma::NumberPredicate.new(@model, alias_name, @attribute, *@query_args)
       when Magma::ChildAttribute, Magma::ForeignKeyAttribute
-        return Magma::RecordPredicate.new(@attribute.link_model, nil, *@predicates)
+        return Magma::RecordPredicate.new(@attribute.link_model, nil, *@query_args)
       when Magma::TableAttribute, Magma::CollectionAttribute
-        return Magma::ModelPredicate.new(@attribute.link_model, *@predicates)
+        return Magma::ModelPredicate.new(@attribute.link_model, *@query_args)
       when Magma::FileAttribute, Magma::ImageAttribute
-        return Magma::FilePredicate.new(@model, alias_name, @attribute.name, *@predicates)
+        return Magma::FilePredicate.new(@model, alias_name, @attribute.name, *@query_args)
       else
         case @attribute.type.name
         when "String"
-          return Magma::StringPredicate.new(@model, alias_name, @attribute.name, *@predicates)
+          return Magma::StringPredicate.new(@model, alias_name, @attribute.name, *@query_args)
         when "Integer", "Float"
-          return Magma::NumberPredicate.new(@model, alias_name, @attribute.name, *@predicates)
+          return Magma::NumberPredicate.new(@model, alias_name, @attribute.name, *@query_args)
         when "DateTime"
-          return Magma::DateTimePredicate.new(@model, alias_name, @attribute.name, *@predicates)
+          return Magma::DateTimePredicate.new(@model, alias_name, @attribute.name, *@query_args)
         when "TrueClass"
-          return Magma::BooleanPredicate.new(@model, alias_name, @attribute.name, *@predicates)
+          return Magma::BooleanPredicate.new(@model, alias_name, @attribute.name, *@query_args)
         else
           invalid_argument! @attribute.name
         end

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -44,6 +44,20 @@ class Magma
       end
     end
 
+    verb '::lacks', :attribute_name do
+      child TrueClass
+
+      constraint do
+        attribute = valid_attribute(@arguments[1])
+        case attribute
+        when Magma::ForeignKeyAttribute
+          basic_constraint(attribute.foreign_id, nil)
+        else
+          basic_constraint(attribute.name, nil)
+        end
+      end
+    end
+
     verb '::metrics' do
       child do
         Magma::MetricsPredicate.new(@model, alias_name, *@query_args)

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -31,7 +31,7 @@ class Magma
         case @attribute
         when Magma::ForeignKeyAttribute
           return [
-            Magma::Question::Join.new(
+            Magma::Join.new(
               @child_predicate.table_name,
               @child_predicate.alias_name,
               :id,
@@ -42,7 +42,7 @@ class Magma
           ]
         when Magma::TableAttribute, Magma::CollectionAttribute, Magma::ChildAttribute
           return [
-            Magma::Question::Join.new(
+            Magma::Join.new(
               @child_predicate.table_name,
               @child_predicate.alias_name,
               @attribute.self_id,
@@ -68,13 +68,13 @@ class Magma
         case @attribute
         when Magma::ForeignKeyAttribute
           return [
-            Magma::Question::Constraint.new(
+            Magma::Constraint.new(
               Sequel.lit("\"#{alias_name}\".\"#{@attribute.foreign_id}\" IS NOT NULL")
             )
           ]
         else
           return [
-            Magma::Question::Constraint.new(
+            Magma::Constraint.new(
               Sequel.lit("\"#{alias_name}\".\"#{@attribute.name}\" IS NOT NULL")
             )
           ]

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -30,7 +30,7 @@ class Magma
       end
     end
 
-    verb "::has", :attribute_name do
+    verb '::has', :attribute_name do
       child TrueClass
 
       constraint do
@@ -44,7 +44,7 @@ class Magma
       end
     end
 
-    verb "::metrics" do
+    verb '::metrics' do
       child do
         Magma::MetricsPredicate.new(@model, alias_name, *@query_args)
       end
@@ -112,13 +112,13 @@ class Magma
         return Magma::FilePredicate.new(@model, alias_name, attribute.name, *@query_args)
       else
         case attribute.type.name
-        when "String"
+        when 'String'
           return Magma::StringPredicate.new(@model, alias_name, attribute.name, *@query_args)
-        when "Integer", "Float"
+        when 'Integer', 'Float'
           return Magma::NumberPredicate.new(@model, alias_name, attribute.name, *@query_args)
-        when "DateTime"
+        when 'DateTime'
           return Magma::DateTimePredicate.new(@model, alias_name, attribute.name, *@query_args)
-        when "TrueClass"
+        when 'TrueClass'
           return Magma::BooleanPredicate.new(@model, alias_name, attribute.name, *@query_args)
         else
           invalid_argument! attribute.name

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -24,16 +24,16 @@ class Magma
     def get_child
       case @argument
       when "::matches"
-        operand = @predicates.shift
+        operand = @query_args.shift
         invalid_argument! operand unless operand && operand.is_a?(String)
         @operand = Regexp.new(operand)
         return terminal(TrueClass)
       when "::equals"
-        @operand = @predicates.shift
+        @operand = @query_args.shift
         invalid_argument! @operand unless @operand && @operand.is_a?(String)
         return terminal(TrueClass)
       when "::in"
-        @operand = @predicates.shift
+        @operand = @query_args.shift
         invalid_argument! @operand unless @operand && @operand.is_a?(Array)
         return terminal(TrueClass)
       when nil

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -4,7 +4,7 @@ class Magma
       child String
     end
 
-    verb "::matches", String do
+    verb '::matches', String do
       child TrueClass
 
       constraint do
@@ -12,7 +12,7 @@ class Magma
       end
     end
 
-    verb "::equals", String do
+    verb '::equals', String do
       child TrueClass
 
       constraint do
@@ -20,7 +20,7 @@ class Magma
       end
     end
 
-    verb "::not", String do
+    verb '::not', String do
       child TrueClass
 
       constraint do
@@ -28,7 +28,7 @@ class Magma
       end
     end
 
-    verb "::in", Array do
+    verb '::in', Array do
       child TrueClass
 
       constraint do
@@ -36,7 +36,7 @@ class Magma
       end
     end
 
-    verb "::not", Array do
+    verb '::not', Array do
       child TrueClass
 
       constraint do

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -1,45 +1,30 @@
 class Magma
   class StringPredicate < Magma::ColumnPredicate
-    def constraint 
-      case @argument
-      when "::matches", "::equals", "::in"
-        return [
-          Magma::Constraint.new(
-            Sequel.qualify(alias_name, @attribute_name) => @operand
-          )
-        ]
+    verb nil do
+      child String
+    end
+
+    verb "::matches", String do
+      child TrueClass
+
+      constraint do
+        basic_constraint(@attribute_name, Regexp.new(@arguments[1]))
       end
-
-      super
     end
 
-    def to_hash
-      super.merge(
-        operand: @operand
-      )
+    verb "::equals", String do
+      child TrueClass
+
+      constraint do
+        basic_constraint(@attribute_name, @arguments[1].to_f)
+      end
     end
 
-    private
+    verb "::in", Array do
+      child TrueClass
 
-    def get_child
-      case @argument
-      when "::matches"
-        operand = @query_args.shift
-        invalid_argument! operand unless operand && operand.is_a?(String)
-        @operand = Regexp.new(operand)
-        return terminal(TrueClass)
-      when "::equals"
-        @operand = @query_args.shift
-        invalid_argument! @operand unless @operand && @operand.is_a?(String)
-        return terminal(TrueClass)
-      when "::in"
-        @operand = @query_args.shift
-        invalid_argument! @operand unless @operand && @operand.is_a?(Array)
-        return terminal(TrueClass)
-      when nil
-        return terminal(String)
-      else
-        invalid_argument! @argument
+      constraint do
+        basic_constraint(@attribute_name, @arguments[1])
       end
     end
   end

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -20,11 +20,27 @@ class Magma
       end
     end
 
+    verb "::not", String do
+      child TrueClass
+
+      constraint do
+        not_constraint(@attribute_name, @arguments[1])
+      end
+    end
+
     verb "::in", Array do
       child TrueClass
 
       constraint do
         basic_constraint(@attribute_name, @arguments[1])
+      end
+    end
+
+    verb "::not", Array do
+      child TrueClass
+
+      constraint do
+        not_constraint(@attribute_name, @arguments[1])
       end
     end
   end

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -4,7 +4,7 @@ class Magma
       case @argument
       when "::matches", "::equals", "::in"
         return [
-          Magma::Question::Constraint.new(
+          Magma::Constraint.new(
             Sequel.qualify(alias_name, @attribute_name) => @operand
           )
         ]

--- a/lib/magma/query/predicate/string.rb
+++ b/lib/magma/query/predicate/string.rb
@@ -16,7 +16,7 @@ class Magma
       child TrueClass
 
       constraint do
-        basic_constraint(@attribute_name, @arguments[1].to_f)
+        basic_constraint(@attribute_name, @arguments[1])
       end
     end
 

--- a/lib/magma/query/predicate/terminal.rb
+++ b/lib/magma/query/predicate/terminal.rb
@@ -4,6 +4,9 @@ class Magma
       @terminal = value
     end
 
+    verb nil do
+    end
+
     def reduced_type
       @terminal
     end

--- a/lib/magma/query/predicate/vector.rb
+++ b/lib/magma/query/predicate/vector.rb
@@ -14,9 +14,7 @@ class Magma
     end
 
     verb nil do
-      child do
-        terminal(Array)
-      end
+      child Array
     end
 
     def extract table, identity

--- a/lib/magma/query/predicate/vector.rb
+++ b/lib/magma/query/predicate/vector.rb
@@ -5,7 +5,7 @@ class Magma
     def initialize model, alias_name, columns, *query_args
       @model = model
       @alias_name = alias_name
-      raise ArgumentError, "Column vector cannot be empty!" if columns.empty?
+      raise ArgumentError, 'Column vector cannot be empty!' if columns.empty?
       @column_predicates = columns.map do |column_query|
         # now, we merely map this to a record predicate. Handy!
         RecordPredicate.new(@model, @alias_name, *column_query)

--- a/lib/magma/query/predicate/vector.rb
+++ b/lib/magma/query/predicate/vector.rb
@@ -2,11 +2,11 @@ class Magma
   # just like the ModelPredicate, this keeps track of its own predicate chain.
   # Confusing... Perhaps a better concept is in order?
   class VectorPredicate < Magma::Predicate
-    def initialize model, alias_name, columns, *predicates
+    def initialize model, alias_name, columns, *query_args
       @model = model
       @alias_name = alias_name
       @columns = columns
-      @predicates = predicates
+      @query_args = query_args
       @child_predicate = get_child
     end
 

--- a/lib/magma/query/question.rb
+++ b/lib/magma/query/question.rb
@@ -1,4 +1,6 @@
 require_relative 'predicate'
+require_relative 'join'
+require_relative 'constraint'
 
 # A query for a piece of data. Each question is a path through the data
 # hierarchy/schema/graph or whatever you want to call it. The basic idea is
@@ -41,67 +43,6 @@ require_relative 'predicate'
 
 class Magma
   class Question
-    class Join
-      def initialize(t1, t1_alias, t1_id, t2, t2_alias, t2_id)
-        @table1 = t1
-        @table1_alias = t1_alias.to_sym
-        @table1_id = t1_id.to_sym
-        @table2_alias = t2_alias.to_sym
-        @table2_id = t2_id.to_sym
-      end
-
-      def apply query
-        query.left_outer_join(
-          Sequel.as(@table1,@table1_alias),
-          table1_column => table2_column
-        )
-      end
-
-      def to_s
-        {table1_column=> table2_column}.to_s
-      end
-
-      def table1_column
-        Sequel.qualify(@table1_alias, @table1_id)
-      end
-
-      def table2_column
-        Sequel.qualify(@table2_alias, @table2_id)
-      end
-
-      def hash
-        table1_column.hash + table2_column.hash
-      end
-
-      def eql?(other)
-        table1_column == other.table1_column && table2_column == other.table2_column
-      end
-    end
-
-    class Constraint
-      attr_reader :conditions
-
-      def initialize(*args)
-        @conditions = args
-      end
-
-      def apply(query)
-        query.where(*@conditions)
-      end
-
-      def to_s
-        @conditions.to_s
-      end
-
-      def hash
-        @conditions.hash
-      end
-
-      def eql?(other)
-        @conditions == other.conditions
-      end
-    end
-
     def initialize(project_name, predicates, options = {})
       @model = Magma.instance.get_model(project_name, predicates.shift)
       @start_predicate = ModelPredicate.new(@model, *predicates)

--- a/lib/magma/query/question.rb
+++ b/lib/magma/query/question.rb
@@ -168,7 +168,7 @@ class Magma
     end
 
     def paged_query(query)
-      raise ArgumentError, "Page must start at 1" unless @options[:page] > 0
+      raise ArgumentError, 'Page must start at 1' unless @options[:page] > 0
       bounds = Magma.instance.db[bounds_query.sql].all.map do |row|
         row[@start_predicate.identity]
       end

--- a/lib/magma/query/question.rb
+++ b/lib/magma/query/question.rb
@@ -43,9 +43,9 @@ require_relative 'constraint'
 
 class Magma
   class Question
-    def initialize(project_name, predicates, options = {})
-      @model = Magma.instance.get_model(project_name, predicates.shift)
-      @start_predicate = ModelPredicate.new(@model, *predicates)
+    def initialize(project_name, query_args, options = {})
+      @model = Magma.instance.get_model(project_name, query_args.shift)
+      @start_predicate = ModelPredicate.new(@model, *query_args)
       @options = options
     end
 

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -19,6 +19,14 @@ class Magma
       instance_variable_defined?("@#{action}")
     end
 
+    def return_type
+      if @child.is_a?(Class)
+        @child.name
+      else
+        nil
+      end
+    end
+
     private
 
     def child(arg=nil, &block)

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -11,6 +11,8 @@ class Magma
       if respond_to?(:"get_#{action}", true)
         send :"get_#{action}", *args
       else
+        require 'pry'
+        binding.pry
         raise ArgumentError, "Verb for #{@predicate} cannot do #{action}"
       end
     end
@@ -21,8 +23,8 @@ class Magma
 
     private
 
-    def child(*args, &block)
-      @child = block_given? ? block : args
+    def child(arg=nil, &block)
+      @child = block_given? ? block : arg
     end
 
     def get_child
@@ -33,17 +35,40 @@ class Magma
         @predicate.instance_exec(&@child)
       when Class
         @predicate.send :terminal, @child
+      else
+        raise ArgumentError, "Cannot determine child_predicate for #{@predicate}"
       end
     end
 
-    def join(*args, &block)
-      @join = block_given? ? block : args
+    def join(arg=nil, &block)
+      @join = block_given? ? block : arg
+    end
+
+    def get_join
+      case @join
+      when Symbol
+        @predicate.send @join
+      when Proc
+        @predicate.instance_exec(&@join)
+      else
+        raise ArgumentError, "Cannot determine join for #{@predicate}"
+      end
     end
 
     def constraint(*args, &block)
       @constraint = block_given? ? block : args
     end
 
+    def get_constraint
+      case @constraint
+      when Symbol
+        @predicate.send @constraint
+      when Proc
+        @predicate.instance_exec(&@constraint)
+      else
+        raise ArgumentError, "Cannot determine constraint for #{@predicate}"
+      end
+    end
     def extract(*args, &block)
       @extract = block_given? ? block : args
     end

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -11,8 +11,6 @@ class Magma
       if respond_to?(:"get_#{action}", true)
         send :"get_#{action}", *args
       else
-        require 'pry'
-        binding.pry
         raise ArgumentError, "Verb for #{@predicate} cannot do #{action}"
       end
     end

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -1,0 +1,55 @@
+class Magma
+  # this class helps define new actions (verbs) handled by a particular Predicate
+  class Verb
+    def initialize(predicate, block)
+      @predicate = predicate
+      @block = block
+      instance_eval(&block)
+    end
+
+    def do(action, *args)
+      if respond_to?(:"get_#{action}", true)
+        send :"get_#{action}", *args
+      else
+        raise ArgumentError, "Verb for #{@predicate} cannot do #{action}"
+      end
+    end
+
+    def gives?(action)
+      instance_variable_defined?("@#{action}")
+    end
+
+    private
+
+    def child(*args, &block)
+      @child = block_given? ? block : args
+    end
+
+    def get_child
+      case @child
+      when Symbol
+        @predicate.send @child
+      when Proc
+        @predicate.instance_exec(&@child)
+      when Class
+        @predicate.send :terminal, @child
+      end
+    end
+
+    def join(*args, &block)
+      @join = block_given? ? block : args
+    end
+
+    def constraint(*args, &block)
+      @constraint = block_given? ? block : args
+    end
+
+    def extract(*args, &block)
+      @extract = block_given? ? block : args
+    end
+
+    def get_extract(*args)
+      @predicate.instance_exec(*args, &@extract)
+    end
+  end
+end

--- a/lib/magma/server/query.rb
+++ b/lib/magma/server/query.rb
@@ -6,6 +6,7 @@ class Magma
     class Query < Magma::Server::Controller
       def response
         begin
+          return success('application/json', Magma::Predicate.to_json) if @params[:query] == '::predicates'
           question = Magma::Question.new(@project_name, @params[:query])
           return_data = {answer: question.answer, type: question.type}
           success('application/json', return_data.to_json)

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -111,6 +111,15 @@ describe Magma::Server::Query do
       expect(json[:answer].length).to eq(1)
     end
 
+    it 'supports ::not' do
+      query(
+        [ 'labor', [ 'name', '::not', 'Nemean Lion' ], '::all', '::identifier' ]
+      )
+
+      json = json_body(last_response.body)
+      expect(json[:answer].length).to eq(2)
+    end
+
     it 'supports ::in' do
       query(
         [ 'labor', [ 'name', '::in', [ 'Nemean Lion', 'Lernean Hydra' ] ], '::all', '::identifier' ]
@@ -118,6 +127,15 @@ describe Magma::Server::Query do
 
       json = json_body(last_response.body)
       expect(json[:answer].length).to eq(2)
+    end
+
+    it 'supports ::not for arrays' do
+      query(
+        [ 'labor', [ 'name', '::not', [ 'Nemean Lion', 'Lernean Hydra' ] ], '::all', '::identifier' ]
+      )
+
+      json = json_body(last_response.body)
+      expect(json[:answer].length).to eq(1)
     end
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -9,6 +9,15 @@ describe Magma::Server::Query do
     json_post(:query, {project_name: 'labors', query: question})
   end
 
+  context Magma::Question do
+    it 'returns a list of predicate definitions' do
+      query('::predicates')
+
+      json = json_body(last_response.body)
+      expect(json[:predicates].keys).to include(:model, :record)
+    end
+  end
+
   context Magma::ModelPredicate do
     it 'supports ::first' do
       poison = create(:prize, name: 'poison', worth: 5)
@@ -204,6 +213,18 @@ describe Magma::Server::Query do
 
     json = json_body(last_response.body)
     expect(json[:answer].length).to eq(3)
+  end
+
+  it "generates an error for bad arguments" do
+    create_list(:labor, 3)
+
+    query(
+      [ 'labor', '::ball', '::bidentifier' ]
+    )
+
+    json = json_body(last_response.body)
+    expect(json[:errors]).to eq(["::ball is not a valid argument to Magma::ModelPredicate"])
+    expect(last_response.status).to eq(422)
   end
 
   it "can return an arrayed result" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -83,6 +83,16 @@ describe Magma::Server::Query do
       expect(json[:answer].first.last).to eq('poison')
     end
 
+    it 'supports ::lacks' do
+      poison = create(:prize, name: 'poison', worth: 5)
+      poop = create(:prize, name: 'poop')
+
+      query(['prize', ['::lacks', 'worth'], '::all', 'name'])
+      
+      json = json_body(last_response.body)
+      expect(json[:answer].first.last).to eq('poop')
+    end
+
     it 'can retrieve metrics' do
       hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
       stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
@@ -186,6 +196,24 @@ describe Magma::Server::Query do
 
       json = json_body(last_response.body)
       expect(json[:answer].length).to eq(1)
+    end
+  end
+
+  context Magma::BooleanPredicate do
+    it 'checks truthiness' do
+      lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+      hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
+      stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
+      query(
+        [ 'labor',
+          [ 'completed', '::false' ],
+          '::all',
+          'name'
+        ]
+      )
+
+      json = json_body(last_response.body)
+      expect(json[:answer].map(&:last)).to eq([ 'Augean Stables', 'Lernean Hydra' ])
     end
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,4 +1,4 @@
-describe Magma::Server::Update do
+describe Magma::Server::Query do
   include Rack::Test::Methods
 
   def app

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -53,6 +53,7 @@ describe Magma::Server::Query do
       hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
       stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
       lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+      hind = create(:labor, name: 'Ceryneian Hind', number: 3, completed: true)
 
       poison = create(:prize, labor: hydra, name: 'poison', worth: 5)
       poop = create(:prize, labor: stables, name: 'poop', worth: 0)
@@ -64,6 +65,7 @@ describe Magma::Server::Query do
       json = json_body(last_response.body)
       expect(json[:answer]).to eq([
         [ 'Augean Stables', 2 ],
+        [ 'Ceryneian Hind', 0 ],
         [ 'Lernean Hydra', 1 ],
         [ 'Nemean Lion', 1 ]
       ])

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -120,7 +120,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(2)
+      expect(json[:answer].map(&:last)).to eq(['Lernean Hydra', 'Nemean Lion'])
     end
 
     it 'supports ::equals' do
@@ -129,7 +129,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(1)
+      expect(json[:answer].first.last).to eq('Nemean Lion')
     end
 
     it 'supports ::not' do
@@ -138,7 +138,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(2)
+      expect(json[:answer].map(&:last)).to eq(['Augean Stables', 'Lernean Hydra'])
     end
 
     it 'supports ::in' do
@@ -147,7 +147,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(2)
+      expect(json[:answer].map(&:last)).to eq(['Lernean Hydra', 'Nemean Lion'])
     end
 
     it 'supports ::not for arrays' do
@@ -156,7 +156,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(1)
+      expect(json[:answer].first.last).to eq('Augean Stables')
     end
   end
 
@@ -177,7 +177,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(2)
+      expect(json[:answer].map(&:last)).to eq(['Lernean Hydra', 'Nemean Lion'])
     end
 
     it 'supports ::in' do
@@ -186,7 +186,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(2)
+      expect(json[:answer].map(&:last)).to eq(['Lernean Hydra', 'Nemean Lion'])
     end
 
     it 'supports ::not' do
@@ -195,7 +195,7 @@ describe Magma::Server::Query do
       )
 
       json = json_body(last_response.body)
-      expect(json[:answer].length).to eq(1)
+      expect(json[:answer].first.last).to eq('Augean Stables')
     end
   end
 
@@ -248,14 +248,14 @@ describe Magma::Server::Query do
   end
 
   it 'can post a basic query' do
-    create_list(:labor, 3)
+    labors = create_list(:labor, 3)
 
     query(
       [ 'labor', '::all', '::identifier' ]
     )
 
     json = json_body(last_response.body)
-    expect(json[:answer].length).to eq(3)
+    expect(json[:answer].map(&:last)).to eq(labors.map(&:identifier))
   end
 
   it 'generates an error for bad arguments' do

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -63,6 +63,41 @@ describe Magma::Server::Retrieve do
     expect(json[:models][:labor][:documents]).not_to have_key(names.last)
   end
 
+  it "retrieves collections as a list of identifiers" do
+    project = create(:project, name: 'The Twelve Labors of Hercules')
+    labors = create_list(:labor, 3, project: project)
+
+    retrieve(
+      model_name: 'project',
+      record_names: [ project.name ],
+      attribute_names: [ 'labor' ],
+      project_name: 'labors'
+    )
+
+    json = json_body(last_response.body)
+    project_doc = json[:models][:project][:documents][project.name.to_sym]
+
+    expect(project_doc).not_to be_nil
+    expect(project_doc[:labor]).to eq(labors.map(&:name))
+  end
+
+  it "returns an empty list for empty collections" do
+    project = create(:project, name: 'The Twelve Labors of Hercules')
+
+    retrieve(
+      model_name: 'project',
+      record_names: [ project.name ],
+      attribute_names: [ 'labor' ],
+      project_name: 'labors'
+    )
+
+    json = json_body(last_response.body)
+    project_doc = json[:models][:project][:documents][project.name.to_sym]
+    
+    expect(project_doc).not_to be_nil
+    expect(project_doc[:labor]).to eq([])
+  end
+
   it "can retrieve records by id if there is no identifier" do
     prizes = create_list(:prize,3)
     retrieve(


### PR DESCRIPTION
This cleans up the "predicate" classes that are used by the Query interface, to clarify the way they work. Mostly this consists of getting rid of switch statements and adding a "verb" interface that matches argument sequences in the query. The result is much cleaner classes that are easier to extend.

I have also added a few new verbs - ::any and ::count to the ModelPredicate and a bunch of new comparison/equality tests to the various value predicates.

There is also a reporting interface on the query endpoint (query('::predicates')) which returns the available predicates and the verb arguments they accept.