### PR TITLE
fix sometime lack of attribute_names

### DIFF
--- a/lib/magma/payload.rb
+++ b/lib/magma/payload.rb
@@ -101,8 +101,9 @@ class Magma
       def json_document record
         # A JSON version of this record (actually a hash). Each attribute
         # reports in its own fashion
+        names = attribute_names || @model.attributes.keys
         Hash[
-          attribute_names.map do |name|
+          names.map do |name|
             [ 
               name, 
               @model.has_attribute?(name) ? @model.attributes[name].json_for(record) : record[name] 

--- a/lib/magma/payload.rb
+++ b/lib/magma/payload.rb
@@ -66,7 +66,7 @@ class Magma
     class ModelPayload
       def initialize model, attribute_names
         @model = model
-        @attribute_names = attribute_names
+        @attribute_names = attribute_names || @model.attributes.keys
         @records = []
       end
 
@@ -101,9 +101,8 @@ class Magma
       def json_document record
         # A JSON version of this record (actually a hash). Each attribute
         # reports in its own fashion
-        names = attribute_names || @model.attributes.keys
         Hash[
-          names.map do |name|
+          @attribute_names.map do |name|
             [ 
               name, 
               @model.has_attribute?(name) ? @model.attributes[name].json_for(record) : record[name] 
@@ -117,7 +116,7 @@ class Magma
       end
 
       def tsv_attributes
-        @tvs_attributes ||= @attribute_names.select do |att_name| 
+        @tsv_attributes ||= @attribute_names.select do |att_name| 
           att_name == :id || (@model.attributes[att_name].shown? && !@model.attributes[att_name].is_a?(Magma::TableAttribute))
         end
       end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -20,6 +20,7 @@ describe Magma::Server::Update do
     )
     lion.refresh
     expect(lion.species).to eq('lion')
+    expect(last_response.status).to eq(200)
   end
 
   it 'can update a collection' do
@@ -36,6 +37,7 @@ describe Magma::Server::Update do
     )
 
     expect(Labors::Labor.count).to be(2)
+    expect(last_response.status).to eq(200)
   end
 
   it 'fails on validation checks' do


### PR DESCRIPTION
This is the price I pay for weak test assertions - my update endpoint correctly changed the DB but returned a 500 instead of a 200 due to some stupid error. I added better assertions and fixed the error.