### PR TITLE
add uploads/ to s3 storage path

### DIFF
--- a/lib/magma/storage.rb
+++ b/lib/magma/storage.rb
@@ -11,7 +11,7 @@ class Magma
       if use_fog?
         @fog.get_object_url(
           @config[:directory],
-          path,
+          "uploads/#{path}",
           Time.now + @config[:expiration]*60,
           path_style: true
         )


### PR DESCRIPTION
Following the use of the Question interface to get records, we now use fog's get_url method to generate an s3 url (instead of letting carrierwave do it through the Sequel model) - however, carrierwave seems to put files into an 'uploads/' directory in s3. We need to format our path correspondingly.