### PR TITLE
Graft fix update revision payload

### DIFF
--- a/lib/magma.rb
+++ b/lib/magma.rb
@@ -88,6 +88,13 @@ class Magma
     end
   end
 
+  attr_reader :logger
+
+  def logger=(logger)
+    db.loggers << logger
+    @logger = logger
+  end
+
   private
 
   def carrier_wave_init

--- a/lib/magma.rb
+++ b/lib/magma.rb
@@ -91,7 +91,7 @@ class Magma
   attr_reader :logger
 
   def logger=(logger)
-    db.loggers << logger
+    db.loggers << logger if db
     @logger = logger
   end
 

--- a/lib/magma/attributes/image.rb
+++ b/lib/magma/attributes/image.rb
@@ -17,7 +17,7 @@ class Magma
     def json_for record
       path = record[@name]
       if path
-        thumb_path = File.join(File.dirname(path), "thumb_#{File.basename(path)}")
+        thumb_path = "thumb_#{path}"
         {
           url: Magma.instance.storage.get_url(path),
           path: File.basename(path),

--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -1,8 +1,10 @@
 require 'extlib'
 require 'date'
+require 'logger'
 
 class Magma
   def run_command(config, cmd = :help, *args)
+    logger = Logger.new('/dev/stdout')
     cmd = cmd.to_sym
     if has_command?(cmd)
       all_commands[cmd].setup(config)

--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 class Magma
   def run_command(config, cmd = :help, *args)
-    logger = Logger.new('/dev/stdout')
+    self.logger = Logger.new('/dev/stdout')
     cmd = cmd.to_sym
     if has_command?(cmd)
       all_commands[cmd].setup(config)

--- a/lib/magma/payload.rb
+++ b/lib/magma/payload.rb
@@ -29,12 +29,6 @@ class Magma
       @models[model].reset
     end
 
-    def add_revision revision
-      add_model revision.model
-
-      add_records revision.model, [ revision.record ]
-    end
-
     def to_hash
       response = {}
 

--- a/lib/magma/revision.rb
+++ b/lib/magma/revision.rb
@@ -1,6 +1,6 @@
 class Magma
   class Revision
-    attr_reader :model, :record_name, :revised_document
+    attr_reader :model, :record_name
     def initialize(model, record_name, revised_document, validator)
       @model = model
       @record = @model[@model.identity => record_name]

--- a/lib/magma/revision.rb
+++ b/lib/magma/revision.rb
@@ -19,6 +19,10 @@ class Magma
       @errors.empty?
     end
 
+    def attribute_names
+      @revised_document.keys
+    end
+
     def post!
       # update the record using this revision
       @revised_document.each do |name, new_value|
@@ -34,7 +38,9 @@ class Magma
     def censored document
       document.select do |att_name,val|
         @model.has_attribute?(att_name) && !@model.attributes[att_name.to_sym].read_only?
-      end
+      end.merge(
+        @model.identity => @record_name
+      )
     end
   end
 end

--- a/lib/magma/revision.rb
+++ b/lib/magma/revision.rb
@@ -1,9 +1,10 @@
 class Magma
   class Revision
-    attr_reader :model, :record
-    def initialize(project_name, model_name, record_name, revised_document, validator)
-      @model = Magma.instance.get_model(project_name, model_name)
+    attr_reader :model, :record_name, :revised_document
+    def initialize(model, record_name, revised_document, validator)
+      @model = model
       @record = @model[@model.identity => record_name]
+      @record_name = record_name
       @revised_document = censored(revised_document || {})
       @validator = validator
     end

--- a/lib/magma/server.rb
+++ b/lib/magma/server.rb
@@ -22,7 +22,7 @@ class Magma
         magma.configure(config)
         magma.load_models
         magma.persist_connection
-        magma.db.loggers << logger
+        magma.logger = logger
       end
     end
 

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -8,8 +8,10 @@ class Magma
         validator = Magma::Validator.new
 
         revisions = @params[:revisions].map do |model_name, model_revisions|
+          model = Magma.instance.get_model(@project_name, model_name)
+
           model_revisions.map do |record_name, revision_data|
-            Magma::Revision.new(@project_name, model_name.to_s, record_name.to_s, revision_data, validator)
+            Magma::Revision.new(model, record_name.to_s, revision_data, validator)
           end
         end.flatten
 

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -28,11 +28,23 @@ class Magma
               @errors.concat m.complaints
               next
             end
-            payload.add_revision revision
           end
         end
 
         if success?
+          revisions.group_by(&:model).each do |model,model_revisions|
+            attribute_names = model_revisions.first.attribute_names
+
+            payload.add_model(model, attribute_names)
+
+            records = Magma::Retrieval.new(
+              model,
+              model_revisions.map(&:record_name),
+              attribute_names.map { |att_name| model.attributes[att_name] }
+            ).records
+
+            payload.add_records(model, records)
+          end
           success 'application/json', payload.to_hash.to_json
         else
           failure(422, errors: @errors)

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -20,6 +20,8 @@ describe Magma::Server::Update do
     )
     lion.refresh
     expect(lion.species).to eq('lion')
+    json = json_body(last_response.body)
+    expect(json[:models][:monster][:documents][:'Nemean Lion']).to eq(name: 'Nemean Lion', species: 'lion')
     expect(last_response.status).to eq(200)
   end
 
@@ -37,13 +39,15 @@ describe Magma::Server::Update do
     )
 
     expect(Labors::Labor.count).to be(2)
+    json = json_body(last_response.body)
+    expect(json[:models][:project][:documents][:'The Two Labors of Hercules']).to eq(name: 'The Two Labors of Hercules', labor: [ 'Lernean Hydra', 'Nemean Lion' ])
     expect(last_response.status).to eq(200)
   end
 
   it 'fails on validation checks' do
     # The actual validation is defined in spec/labors/models/monster.rb,
     # not sure how to move it here
-    lion = create(:monster, name: "Nemean Lion", species: "lion")
+    lion = create(:monster, name: 'Nemean Lion', species: 'lion')
     post(
       '/update',
       {


### PR DESCRIPTION
This fixes a few update-related bugs:

1) Thumbnail display was broken because the URL was not generated correctly, and S3 does some weird things with filenames.

2) The main update loop would not return a correct payload, resulting in empty values being returned, which would wipe out part of the record in the JS store (which could lead to bad revisions in the future) - e.g., if I edit a patient, the returned JSON document describing the update might have NULL for the 'sample' collection attribute instead of [ 's1', 's2' ] - if you then re-edited the patient, you began with a NULL entry, very bad. All of this began because the Magma::Payload class was reformed for the retrieve endpoint, but also got used by the update endpoint to send back revisions; this was not working.

The Magma::Attribute classes no longer format ORM records as JSON, they format whatever comes out of the Question interface. This made it hard to return a correctly-formatted revision using a Payload (especially for files), so I opted for simply retrieving the records with a Retrieval after updating and sending back the payload in the same fashion as the retrieve endpoint.

This is the last of the great bug fixes that I need to get Timur back up and running.