### PR TITLE
fix /dev/stdout  to STDOUT

### DIFF
--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 class Magma
   def run_command(config, cmd = :help, *args)
-    self.logger = Logger.new('/dev/stdout')
+    self.logger = Logger.new(STDOUT)
     cmd = cmd.to_sym
     if has_command?(cmd)
       all_commands[cmd].setup(config)


### PR DESCRIPTION
Halfway through the deploy things fell apart because I wrote to /dev/stdout for the command interface, and apparently this does not always work. Logging to STDOUT instead...