### PR TITLE
Graft fix linking and validation

### DIFF
--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -114,7 +114,7 @@ class Magma
       puts <<EOT
 Sequel.migration do
   change do
-    #{Magma.instance.magma_projects.values.map(&:models).map(&:values).flatten.map(&:migration).reject(&:empty?).join("\n")}
+    #{Magma.instance.magma_projects.values.map(&:migrations).flatten.join("\n")}
   end
 end
 EOT

--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -114,7 +114,7 @@ class Magma
       puts <<EOT
 Sequel.migration do
   change do
-#{Magma.instance.magma_models.map(&:migration).reject(&:empty?).join("\n")}
+    #{Magma.instance.magma_projects.values.map(&:models).map(&:values).flatten.map(&:migration).reject(&:empty?).join("\n")}
   end
 end
 EOT

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -19,6 +19,10 @@ class Magma
       ]
     end
 
+    def migrations
+      models.values.map(&:migration).reject(&:empty?)
+    end
+
     private
 
     def project_container

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -1,0 +1,48 @@
+class Magma
+  class Project
+    attr_reader :project_name
+
+    def initialize project_dir
+      @project_dir = project_dir
+      @project_name = project_dir.split('/').last.to_sym
+
+      load_project
+    end
+
+    def models
+      @models ||= Hash[
+        project_container.constants(false).map do |c|
+          project_container.const_get(c) 
+        end.select do |m| m < Magma::Model end.map do |m|
+          [ m.model_name, m ]
+        end
+      ]
+    end
+
+    private
+
+    def project_container
+      @project_container ||= Kernel.const_get(@project_name.to_s.camel_case)
+    end
+
+    def load_project
+      base_file = project_file('requirements.rb')
+      if File.exists?(base_file)
+        require base_file 
+      else
+        require_files('models')
+        require_files('loaders')
+        require_files('metrics')
+      end
+    end
+
+    def require_files folder
+      Dir.glob(project_file(folder, '**', '*.rb'), &method(:require))
+    end
+
+    def project_file *filenames
+      File.join(File.dirname(__FILE__), '../..', @project_dir, *filenames)
+    end
+
+  end
+end

--- a/lib/magma/server/retrieve.rb
+++ b/lib/magma/server/retrieve.rb
@@ -95,7 +95,7 @@ class Magma
 
         # Pull the data.
         if @model_name == 'all'
-          Magma.instance.magma_models.each do |model|
+          Magma.instance.get_project(@project_name).models.each do |model_name, model|
             next if @attribute_names == 'identifier' && !model.has_identifier?
             retrieve_model(model)
           end

--- a/spec/labors/models/monster.rb
+++ b/spec/labors/models/monster.rb
@@ -4,5 +4,6 @@ module Labors
 
     identifier :name, type: String
     attribute :species, type: String, match: /^[a-z\s]+$/
+    collection :victim
   end
 end

--- a/spec/magma_model_spec.rb
+++ b/spec/magma_model_spec.rb
@@ -2,101 +2,19 @@ require_relative '../lib/magma'
 require 'yaml'
 
 describe Magma::Model do
-  describe '.validate' do
-    it 'ensures the table exists' do
-    end
-  end
-
-  describe '.attributes' do
-    it 'returns a hash of attributes for this model' do
-    end
-  end
-
-  describe '.identity' do
-    it 'gives the key name for the model\'s identifier' do
-    end
-    it 'returns id if model has no identifier' do
-    end
-  end
-
-  describe '.display_attributes' do
-    it 'returns the class for a given model name' do
-    end
-  end
-
-  describe '.order' do
-    it 'orders the dataset by column' do
-    end
-  end
-
   describe '.has_attribute?' do
     it 'determines whether an attribute exists' do
-    end
-  end
-
-  context 'Attribute descriptions' do
-    describe '.attribute' do
-      it 'defines a basic attribute' do
-      end
-    end
-    describe '.identifier' do
-      it 'creates an attribute and makes it the identifier' do
-      end
-    end
-    describe '.parent' do
-      it 'creates a foreign_key attribute' do
-      end
-    end
-    describe '.link' do
-      it 'creates a foreign_key attribute' do
-      end
-    end
-    describe '.document' do
-      it 'creates a document attribute' do
-      end
-    end
-    describe '.image' do
-      it 'creates an image attribute' do
-      end
-    end
-    describe '.collection' do
-      it 'creates a collection attribute' do
-      end
+      expect(Labors::Monster.has_attribute?(:species)).to be_truthy
+      expect(Labors::Monster.has_attribute?(:nonexistent_attribute_name)).to be_falsy
     end
   end
 
   describe '.json_template' do
     it 'returns a json template describing the model' do
-    end
-  end
+      template = Labors::Monster.json_template
 
-  describe '.schema' do
-    it 'returns the sequel database schema for this model' do
-    end
-  end
-
-  describe '.multi_update' do
-    it 'updates multiple records at once from an array of json hashes' do
-    end
-  end
-
-  describe '.update_or_create' do
-    it 'updates or creates a record' do
-    end
-  end
-
-  describe '#identifier' do
-    it 'returns the value of the identifier for this record' do
-    end
-  end
-
-  describe '#run_loaders' do
-    it 'runs the specified loader on a particular file' do
-    end
-  end
-
-  describe '#json_document' do
-    it 'returns a json document describing this record' do
+      expect(template.values_at(:name, :identifier, :parent)).to eq([:monster, :name, :labor])
+      expect(template[:attributes].keys).to include(:created_at, :updated_at, :labor, :name, :species)
     end
   end
 end

--- a/spec/magma_spec.rb
+++ b/spec/magma_spec.rb
@@ -1,23 +1,82 @@
 require_relative '../lib/magma'
 require 'yaml'
 
+def disconnect_attribute model, att_name
+  att = model.attributes[att_name]
+  model.attributes[att_name] = nil
+  att
+end
+
+def reconnect_attribute model, att_name, value
+  model.attributes[att_name] = value
+end
+
+def reset_models project
+  Magma.instance.get_project(project).instance_variable_set("@models",nil)
+end
+
 describe Magma do
-  describe '.connect' do
-    it 'creates a Sequel database connection' do
-    end
-  end
-
-  describe '.configure' do
-    it 'loads models and validates tables' do
-    end
-  end
-
-  describe '.get_model' do
+  describe '#get_model' do
     it 'returns the class for a given model name' do
+      model = Magma.instance.get_model('labors','project')
+
+      expect(model).to eq(Labors::Project)
+    end
+    it 'raises if the model does not exist' do
+      expect {
+        Magma.instance.get_model('labors','nonexistent_model')
+      }.to raise_error(NameError)
     end
   end
-  describe '.magma_models' do
-    it 'returns a list of all magma models' do
+
+  describe '#validate_models' do
+    context 'two-way links' do
+      before(:each) do
+        @labor = disconnect_attribute(Labors::Monster, :labor)
+      end
+      after(:each) do
+        reconnect_attribute(Labors::Monster, :labor, @labor)
+      end
+      it 'complains without reciprocal links' do
+        expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
+      end
+    end
+    context 'project model' do
+      before(:each) do
+        # Delete the constant
+        @project = Labors::Project
+        Labors.send(:remove_const,:Project)
+
+        # Reset the Magma::Project object's model cache
+        reset_models(:labors)
+
+        # Unlink the labor model's project attribute
+        @project_att = disconnect_attribute(Labors::Labor,:project)
+      end
+      after(:each) do
+        Labors::Project = @project
+
+        reset_models(:labors)
+
+        reconnect_attribute(Labors::Labor, :project, @project_att)
+      end
+      it 'complains if no project model is present' do
+        expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
+      end
+    end
+    context 'orphan models' do
+      before(:each) do
+        # Unlink the labor model and prize model
+        @labor_att = disconnect_attribute(Labors::Prize,:labor)
+        @prize_att = disconnect_attribute(Labors::Labor,:prize)
+      end
+      after(:each) do
+        reconnect_attribute(Labors::Labor, :prize, @prize_att)
+        reconnect_attribute(Labors::Prize, :labor, @labor_att)
+      end
+      it 'complains if there are orphan models' do
+        expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
+      end
     end
   end
 end


### PR DESCRIPTION
This does two main things:

1) Adds Magma#get_project, Magma#magma_projects, which make use of a new Magma::Project class which collects all of its own models and so on.

2) Adds in a bunch of validations when the model loads:
  - There must be a Project model for each project
  - Model names cannot be certain reserved words
  - Models must have reciprocal links - if A links to B, B must link to A somehow.
  - Models cannot be orphans - they must link to another model

There is a problem with the orphan model test, which is that you can have two or more orphans clutching each other and still disconnected from the Project model, really we should validate that there is a path to Project somehow.