### PR TITLE
query time out

### DIFF
--- a/lib/magma/query/query_executor.rb
+++ b/lib/magma/query/query_executor.rb
@@ -1,0 +1,24 @@
+class Magma
+  class QueryExecutor
+    def initialize(query, timeout, db)
+      @query = query
+      @timeout = timeout
+      @db = db
+
+      raise ArgumentError, 'Timeout only works with postgres' if @timeout && @db.adapter_scheme != :postgres
+    end
+
+    def execute
+      @timeout ? with_timeout { @db[@query.sql].all } : @db[@query.sql].all
+    end
+
+    private
+
+    def with_timeout
+      @db.transaction do
+        @db.run("SET LOCAL statement_timeout = #{@timeout}")
+        yield
+      end
+    end
+  end
+end

--- a/lib/magma/server/query.rb
+++ b/lib/magma/server/query.rb
@@ -6,10 +6,10 @@ class QueryController < Magma::Controller
     return failure(401, errors: [ 'You are unauthorized' ]) unless @user && @user.can_view?(@project_name)
     begin
       return success(Magma::Predicate.to_json, 'application/json') if @params[:query] == '::predicates'
-      question = Magma::Question.new(@project_name, @params[:query])
+      question = Magma::Question.new(@project_name, @params[:query], :timeout => 300000)
       return_data = {answer: question.answer, type: question.type}
       return success(return_data.to_json, 'application/json')
-    rescue ArgumentError => e
+    rescue StandardError => e
       puts e.backtrace
       return failure(422, errors: [ e.message ])
     end

--- a/lib/magma/server/query.rb
+++ b/lib/magma/server/query.rb
@@ -6,12 +6,16 @@ class QueryController < Magma::Controller
     return failure(401, errors: [ 'You are unauthorized' ]) unless @user && @user.can_view?(@project_name)
     begin
       return success(Magma::Predicate.to_json, 'application/json') if @params[:query] == '::predicates'
-      question = Magma::Question.new(@project_name, @params[:query], :timeout => 300000)
+      question = Magma::Question.new(@project_name, @params[:query],
+                                     :timeout => Magma.instance.config(:query_timeout))
       return_data = {answer: question.answer, type: question.type}
       return success(return_data.to_json, 'application/json')
-    rescue StandardError => e
+    rescue ArgumentError => e
       puts e.backtrace
       return failure(422, errors: [ e.message ])
+    rescue Sequel::DatabaseError => e
+      puts e.backtrace
+      return failure(501, errors: [ e.message ])
     end
   end
 end

--- a/spec/query_executor_spec.rb
+++ b/spec/query_executor_spec.rb
@@ -1,0 +1,56 @@
+require 'rspec'
+require 'sequel'
+
+describe 'QueryExecutor' do
+
+  mock_db = Sequel.connect('mock://DB')
+
+  it 'should raise an error when a timeout is provided and the database is not postgres' do
+    expect { Magma::QueryExecutor.new(Sequel.mock, 10, mock_db) }.to raise_error(ArgumentError)
+  end
+
+  it 'should use a statement_timeout when provided a timeout' do
+    allow(mock_db).to receive(:adapter_scheme) { :postgres }
+    query = 'SELECT * FROM mocks'
+    Magma::QueryExecutor.new(mock_db[query], 10, mock_db).execute
+
+    expected = "
+      BEGIN
+      SET LOCAL statement_timeout = 10
+      #{query}
+      COMMIT
+    ".strip.split("\n").map(&:strip)
+
+    expect(mock_db.sqls).to eq(expected)
+  end
+
+  it 'should not use a statement_timeout when a timeout is not set' do
+    allow(mock_db).to receive(:adapter_scheme) { :postgres }
+    query = 'SELECT * FROM mocks'
+    Magma::QueryExecutor.new(mock_db[query], nil, mock_db).execute
+    expect(mock_db.sqls.first).to eq(query)
+  end
+
+  it 'should raise an error when the query execution surpasses the timeout' do
+    db = Magma.instance.db
+    query = db['fake query that takes a long time']
+    allow(query).to receive(:sql) { 'SELECT pg_sleep(1);' }
+
+    expect { Magma::QueryExecutor.new(query, 900, db).execute }.to raise_error(Sequel::DatabaseError)
+  end
+
+  it 'should fetch rows' do
+    project = create(:project, name: 'The Twelve Labors of Hercules')
+    labors = create_list(:labor, 4, project: project)
+    names = labors.map(&:name).sort
+
+    db = Magma.instance.db
+    query = db['SELECT * FROM labors.labors']
+
+    results = Magma::QueryExecutor.new(query, nil, db).execute.map{ |row| row[:name] }.sort
+    expect(results).to eq(names)
+
+    results = Magma::QueryExecutor.new(query, 1000, db).execute.map{ |row| row[:name] }.sort
+    expect(results).to eq(names)
+  end
+end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -44,6 +44,16 @@ describe Magma::QueryController do
     expect(last_response.status).to eq(403)
   end
 
+  it 'generates a 501 error from a DB error' do
+    allow_any_instance_of(Magma::Question).to receive(:answer).and_raise(Sequel::DatabaseError)
+
+    query(
+        [ 'labor', '::all', '::identifier' ]
+    )
+
+    expect(last_response.status).to eq(501)
+  end
+
   context Magma::Question do
     it 'returns a list of predicate definitions' do
       query('::predicates')

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -18,7 +18,7 @@ describe Magma::QueryController do
     )
 
     json = json_body(last_response.body)
-    expect(json[:answer].map(&:last)).to eq(labors.map(&:identifier))
+    expect(json[:answer].map(&:last).sort).to eq(labors.map(&:identifier).sort)
   end
 
   it 'generates an error for bad arguments' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -132,6 +132,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     FactoryBot.find_definitions
+    DatabaseCleaner[:sequel].db = Magma.instance.db
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
related to this issue #65 

- Manage the query timeouts within the question, so that database roles don't have to be changed and timeouts can be managed for read queries

- query is done inside a transaction with a local statement_timeout, only works for postgres

- timeout set to 5 minutes in the query controller

