### PR TITLE
support logging in db again

### DIFF
--- a/lib/magma/server.rb
+++ b/lib/magma/server.rb
@@ -11,6 +11,8 @@ class Magma
       super
       application.tap do |magma|
         magma.load_models
+
+        magma.db.loggers << @logger
       end
     end
 


### PR DESCRIPTION
The Sequel query-logging seems to have been axed in the etna-server update, adding it back in.