### PR TITLE
fix retrieve endpoint to re-allow grabbing identifiers (only) for all records/models

### DIFF
--- a/lib/magma/server/retrieve.rb
+++ b/lib/magma/server/retrieve.rb
@@ -79,7 +79,8 @@ class RetrieveController < Magma::Controller
     return error('No record names given') if @record_names.nil?
     return error('Improperly formed record names') unless valid_record_names?
     return error("Improperly formed attribute names") unless @attribute_names.is_a?(Array) || @attribute_names == "all" || @attribute_names == "identifier"
-    return error('Cannot retrieve by record name for all models') if @model_name == "all" && (!@record_names.is_a?(Array) || !@record_names.empty?)
+    return error('Cannot retrieve by record name for all models') if @model_name == "all" && @record_names.is_a?(Array) && !@record_names.empty?
+    return error('Can only retrieve identifiers for all records for all models') if @model_name == "all" && @record_names == "all" && @attribute_names != "identifier"
     return error('Cannot retrieve several models in tsv format') if @model_name == "all" && @format == "tsv"
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,4 +1,4 @@
-describe Magma::QueryController do
+describe QueryController do
   include Rack::Test::Methods
 
   def app

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -43,16 +43,16 @@ describe Magma::RetrieveController do
       project_name: 'labors',
       model_name: 'all',
       record_names: [],
-      attribute_names: "all"
+      attribute_names: 'all'
     )
     expect(last_response).to(be_ok)
   end
 
-  it "complains if there are record names for all models" do
+  it 'complains if there are record names for all models' do
     retrieve(
       project_name: 'labors',
-      model_name: "all",
-      record_names: [ "record1", "record2" ],
+      model_name: 'all',
+      record_names: [ 'record1', 'record2' ],
       attribute_names: []
     )
 
@@ -64,12 +64,28 @@ describe Magma::RetrieveController do
       project_name: 'labors',
       model_name: 'all',
       record_names: 'all',
-      attribute_names: "all"
+      attribute_names: 'all'
     )
     expect(last_response.status).to eq(422)
   end
 
-  it "retrieves records by identifier" do
+  it 'allows grabbing the entire set of identifiers' do
+    labors = create_list(:labor,3)
+    monsters = create_list(:monster,3)
+    retrieve(
+      project_name: 'labors',
+      model_name: 'all',
+      record_names: 'all',
+      attribute_names: 'identifier'
+    )
+    expect(last_response.status).to eq(200)
+    json = json_body(last_response.body)
+
+    expect(json[:models][:labor][:documents].keys).to eq(labors.map(&:name).map(&:to_sym))
+    expect(json[:models][:monster][:documents].keys).to eq(monsters.map(&:name).map(&:to_sym))
+  end
+
+  it 'retrieves records by identifier' do
     labors = create_list(:labor,3)
 
     names = labors.map(&:name).map(&:to_sym)
@@ -87,7 +103,7 @@ describe Magma::RetrieveController do
     expect(json[:models][:labor][:documents]).not_to have_key(names.last)
   end
 
-  it "retrieves collections as a list of identifiers" do
+  it 'retrieves collections as a list of identifiers' do
     project = create(:project, name: 'The Twelve Labors of Hercules')
     labors = create_list(:labor, 3, project: project)
 
@@ -105,7 +121,7 @@ describe Magma::RetrieveController do
     expect(project_doc[:labor]).to eq(labors.map(&:name))
   end
 
-  it "returns an empty list for empty collections" do
+  it 'returns an empty list for empty collections' do
     project = create(:project, name: 'The Twelve Labors of Hercules')
 
     retrieve(
@@ -122,24 +138,24 @@ describe Magma::RetrieveController do
     expect(project_doc[:labor]).to eq([])
   end
 
-  it "can retrieve records by id if there is no identifier" do
+  it 'can retrieve records by id if there is no identifier' do
     prizes = create_list(:prize,3)
     retrieve(
       project_name: 'labors',
-      model_name: "prize",
+      model_name: 'prize',
       record_names: prizes[0..1].map(&:id),
-      attribute_names: "all" 
+      attribute_names: 'all' 
     )
 
-    json = JSON.parse(last_response.body)
+    json = json_body(last_response.body)
 
-    expect(json["models"]["prize"]["documents"]).to have_key(prizes[0].id.to_s)
-    expect(json["models"]["prize"]["documents"]).not_to have_key(prizes[2].id.to_s)
+    expect(json[:models][:prize][:documents]).to have_key(prizes[0].id.to_s.to_sym)
+    expect(json[:models][:prize][:documents]).not_to have_key(prizes[2].id.to_s.to_sym)
   end
 
-  it "can retrieve a TSV of data from the endpoint" do
+  it 'can retrieve a TSV of data from the endpoint' do
     labor_list = create_list(:labor, 12)
-    required_atts = ["name", "number", "completed"]
+    required_atts = ['name', 'number', 'completed']
     retrieve(
       model_name: 'labor',
       record_names: 'all',
@@ -153,38 +169,38 @@ describe Magma::RetrieveController do
     expect(table.length).to eq(12)
   end
 
-  it "can retrieve a TSV of data without an identifier" do
+  it 'can retrieve a TSV of data without an identifier' do
     prize_list = create_list(:prize, 12)
     retrieve(
       project_name: 'labors',
-      model_name: "prize",
-      record_names: "all",
-      attribute_names: "all",
-      format: "tsv"
+      model_name: 'prize',
+      record_names: 'all',
+      attribute_names: 'all',
+      format: 'tsv'
     )
     header, *table = CSV.parse(last_response.body, col_sep: "\t")
 
     expect(table.length).to eq(12)
   end
 
-  it "can use a filter" do
-    lion = create(:labor, name: "Nemean Lion", number: 1, completed: true)
-    hydra = create(:labor, name: "Lernean Hydra", number: 2, completed: false)
-    stables = create(:labor, name: "Augean Stables", number: 5, completed: false)
+  it 'can use a filter' do
+    lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+    hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
+    stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
     retrieve(
       project_name: 'labors',
-      model_name: "labor",
-      record_names: "all",
-      attribute_names: "all",
-      filter: "name~L"
+      model_name: 'labor',
+      record_names: 'all',
+      attribute_names: 'all',
+      filter: 'name~L'
     )
 
-    json = JSON.parse(last_response.body)
+    json = json_body(last_response.body)
     expect(last_response.status).to eq(200)
-    expect(json["models"]["labor"]["documents"].count).to eq(2)
+    expect(json[:models][:labor][:documents].count).to eq(2)
   end
 
-  it "can filter on numbers" do
+  it 'can filter on numbers' do
     poison = create(:prize, name: 'poison', worth: 5)
     poop = create(:prize, name: 'poop', worth: 0)
     iou = create(:prize, name: 'iou', worth: 2)
@@ -204,7 +220,7 @@ describe Magma::RetrieveController do
     expect(prize_names).to eq(['poison', 'skin'])
   end
 
-  it "can filter on dates" do
+  it 'can filter on dates' do
     old_labors = create_list(:labor, 3, year: DateTime.new(500))
     new_labors = create_list(:labor, 3, year: DateTime.new(2000))
 
@@ -247,24 +263,24 @@ describe Magma::RetrieveController do
     Timecop.return
   end
 
-  it "can page results" do
+  it 'can page results' do
     labor_list = create_list(:labor, 9)
     names = labor_list.sort_by(&:name)[6..8].map(&:name)
 
     retrieve(
       project_name: 'labors',
-      model_name: "labor",
-      record_names: "all",
-      attribute_names: "all",
+      model_name: 'labor',
+      record_names: 'all',
+      attribute_names: 'all',
       page: 3,
       page_size: 3
     )
 
-    json = JSON.parse(last_response.body)
-    expect(json["models"]["labor"]["documents"].keys).to eq(names)
+    json = json_body(last_response.body)
+    expect(json[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
   end
 
-  it "can page results with joined collections" do
+  it 'can page results with joined collections' do
     monster_list = create_list(:monster, 9)
     victim_list = monster_list.map do |monster|
       create_list(:victim, 2, monster: monster)
@@ -274,37 +290,37 @@ describe Magma::RetrieveController do
 
     retrieve(
       project_name: 'labors',
-      model_name: "monster",
-      record_names: "all",
-      attribute_names: "all",
+      model_name: 'monster',
+      record_names: 'all',
+      attribute_names: 'all',
       page: 3,
       page_size: 3
     )
 
-    json = JSON.parse(last_response.body)
-    expect(json["models"]["monster"]["documents"].keys).to eq(names)
+    json = json_body(last_response.body)
+    expect(json[:models][:monster][:documents].keys).to eq(names.map(&:to_sym))
   end
 
-  it "returns a count of total records for page 1" do
+  it 'returns a count of total records for page 1' do
     labor_list = create_list(:labor, 9)
 
     retrieve(
       project_name: 'labors',
-      model_name: "labor",
-      record_names: "all",
-      attribute_names: "all",
+      model_name: 'labor',
+      record_names: 'all',
+      attribute_names: 'all',
       page: 1,
       page_size: 3
     )
 
-    json = JSON.parse(last_response.body)
-    expect(json["models"]["labor"]["count"]).to eq(9)
+    json = json_body(last_response.body)
+    expect(json[:models][:labor][:count]).to eq(9)
   end
 
-  it "retrieves table associations" do
-    lion = create(:labor, name: "Nemean Lion", number: 1, completed: true)
-    hydra = create(:labor, name: "Lernean Hydra", number: 2, completed: false)
-    stables = create(:labor, name: "Augean Stables", number: 5, completed: false)
+  it 'retrieves table associations' do
+    lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+    hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
+    stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
     lion_prizes = create_list(:prize, 3, labor: lion)
     hydra_prizes = create_list(:prize, 3, labor: hydra)
     stables_prizes = create_list(:prize, 3, labor: stables)
@@ -315,13 +331,13 @@ describe Magma::RetrieveController do
 
     retrieve(
       project_name: 'labors',
-      model_name: "labor",
-      record_names: [ "Nemean Lion", "Lernean Hydra" ],
-      attribute_names: [ "prize" ]
+      model_name: 'labor',
+      record_names: [ 'Nemean Lion', 'Lernean Hydra' ],
+      attribute_names: [ 'prize' ]
     )
 
-    json = JSON.parse(last_response.body)
-    expect(json["models"]["labor"]["documents"].size).to eq(2)
-    expect(json["models"]["prize"]["documents"].keys.sort).to eq(selected_prize_ids)
+    json = json_body(last_response.body)
+    expect(json[:models][:labor][:documents].size).to eq(2)
+    expect(json[:models][:prize][:documents].keys.sort.map(&:to_s)).to eq(selected_prize_ids)
   end
 end

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -1,4 +1,4 @@
-describe Magma::RetrieveController do
+describe RetrieveController do
   include Rack::Test::Methods
 
   def app
@@ -72,6 +72,7 @@ describe Magma::RetrieveController do
   it 'allows grabbing the entire set of identifiers' do
     labors = create_list(:labor,3)
     monsters = create_list(:monster,3)
+    prizes = create_list(:prize,3)
     retrieve(
       project_name: 'labors',
       model_name: 'all',
@@ -81,8 +82,12 @@ describe Magma::RetrieveController do
     expect(last_response.status).to eq(200)
     json = json_body(last_response.body)
 
+    # any model with an identifier returns all records
     expect(json[:models][:labor][:documents].keys).to eq(labors.map(&:name).map(&:to_sym))
     expect(json[:models][:monster][:documents].keys).to eq(monsters.map(&:name).map(&:to_sym))
+
+    # it does not return a model with no identifier
+    expect(json[:models][:prize]).to be_nil
   end
 
   it 'retrieves records by identifier' do
@@ -133,7 +138,7 @@ describe Magma::RetrieveController do
 
     json = json_body(last_response.body)
     project_doc = json[:models][:project][:documents][project.name.to_sym]
-    
+
     expect(project_doc).not_to be_nil
     expect(project_doc[:labor]).to eq([])
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,18 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  # suppress annoying console output during the run
+  original_stderr = $stderr
+  original_stdout = $stdout
+  config.before(:all) do
+    $stderr = File.open(File::NULL, "w")
+    $stdout = File.open(File::NULL, "w")
+  end
+  config.after(:all) do
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
+
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -1,4 +1,4 @@
-describe Magma::UpdateController do
+describe UpdateController do
   include Rack::Test::Methods
 
   def app


### PR DESCRIPTION
A victim of poor test coverage, a previous change, meant to prevent 'grabbing the entire dataset' also prevented 'grabbing just the identifiers for the entire dataset'. I fixed, added in a test to cover the specific case, and made some stylish improvements to the spec.