### PR TITLE
fix client status_check

### DIFF
--- a/gem/lib/client.rb
+++ b/gem/lib/client.rb
@@ -111,12 +111,12 @@ class Magma
     def request(uri, data, status_errors, &block)
       if block_given?
         persistent_connection.request(uri, data) do |response|
-          #status_check(response, status_errors)
+          status_check(response, status_errors)
           yield response
         end
       else
         response = persistent_connection.request(uri, data)
-        #status_check(response, status_errors)
+        status_check(response, status_errors)
         return response
       end
     end

--- a/gem/magma.gemspec
+++ b/gem/magma.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'magma'
-  spec.version = '0.5'
+  spec.version = '0.5.1'
   spec.summary = 'Magma client gem'
   spec.description = 'See summary'
   spec.email = 'Saurabh.Asthana@ucsf.edu'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'rack/test'
 require 'etna'
 require 'simplecov'
 require 'timecop'
+require 'webmock/rspec'
+
 SimpleCov.start
 
 


### PR DESCRIPTION
This enables status_check in the magma client and also changes the way the client spec works so that it uses webmock instead of stubbing out internal client methods. Now the client stack is tested completely (except this depends on fixing a problem with Etna::TestAuth, so the spec won't pass until that is updated).