### PR TITLE
adds etna::cross_origin layer so magma can serve requests to browser clients

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,8 +5,10 @@ Bundler.require(:default)
 require_relative 'lib/magma/server'
 require_relative 'lib/magma'
 
+use Etna::CrossOrigin
 use Etna::ParseBody
 use Etna::SymbolizeParams
 use Etna::Auth
+
 
 run Magma::Server.new(YAML.load(File.read('config.yml')))


### PR DESCRIPTION
This lets magma use the new etna cross_origin rack layer, which allows it to respond correctly to CORS requests from browsers (so, e.g., timur.ucsf.edu can talk directly to magma.ucsf.edu via the browser).