### PR TITLE
allow each project repo to track its own gems and bundle with magma's Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,7 @@ group :test do
   gem 'pry'
   gem 'timecop'
 end
+
+Dir.glob File.expand_path("projects/*/Gemfile",__dir__) do |file|
+  instance_eval File.read(file)
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,15 @@ GEM
   remote: http://rubygems.org/
   specs:
     CFPropertyList (2.3.6)
-    activemodel (5.1.4)
-      activesupport (= 5.1.4)
-    activesupport (5.1.4)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     builder (3.2.3)
-    carrierwave (1.2.1)
+    carrierwave (1.2.2)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -19,22 +19,23 @@ GEM
       sequel
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    database_cleaner (1.6.2)
+    curb (0.9.4)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
-    docile (1.1.5)
-    domain_name (0.5.20170404)
+    docile (1.3.0)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    etna (0.1)
+    etna (0.1.2)
       extlib
       jwt
       rack
-    excon (0.60.0)
+    excon (0.62.0)
     extlib (0.9.16)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.42.0)
+    fog (2.0.0)
       fog-aliyun (>= 0.1.0)
       fog-atmos
       fog-aws (>= 0.6.0)
@@ -69,7 +70,7 @@ GEM
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
       json (~> 2.0)
-    fog-aliyun (0.2.0)
+    fog-aliyun (0.2.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       ipaddress (~> 0.8)
@@ -77,7 +78,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (2.0.0)
+    fog-aws (2.0.1)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -124,17 +125,18 @@ GEM
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-local (0.4.0)
-      fog-core (~> 1.27)
-    fog-openstack (0.1.22)
-      fog-core (>= 1.40)
+    fog-local (0.5.0)
+      fog-core (>= 1.27, < 3.0)
+    fog-openstack (0.1.25)
+      fog-core (~> 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
-    fog-ovirt (0.1.2)
+    fog-ovirt (1.0.3)
       fog-core (~> 1.45)
       fog-json
       fog-xml (~> 0.1.1)
-      rbovirt (~> 0.1.4)
+      ovirt-engine-sdk (>= 4.1.3)
+      rbovirt (~> 0.1.5)
     fog-powerdns (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -176,7 +178,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.13.1)
+    fog-vsphere (2.1.1)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -188,7 +190,7 @@ GEM
     formatador (0.2.5)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.1)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
     ipaddress (0.8.3)
@@ -200,22 +202,24 @@ GEM
     mime-types-data (3.2016.0521)
     mini_magick (4.8.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
-    multi_json (1.12.2)
+    minitest (5.11.3)
+    multi_json (1.13.1)
     netrc (0.11.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    pg (0.21.0)
+    ovirt-engine-sdk (4.2.4)
+      json (>= 1, < 3)
+    pg (1.0.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.3)
-    rack-test (0.8.2)
+    rack (2.0.5)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
-    rbovirt (0.1.4)
+    rbovirt (0.1.5)
       nokogiri
       rest-client (> 1.7.0)
-    rbvmomi (1.11.6)
+    rbvmomi (1.12.0)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
@@ -228,7 +232,7 @@ GEM
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -236,23 +240,24 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     ruby-ole (1.2.12.1)
     sequel (4.49.0)
-    simplecov (0.15.1)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spreadsheet (1.1.5)
+    spreadsheet (1.1.7)
       ruby-ole (>= 1.0)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     trollop (2.1.2)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     xml-simple (1.1.5)
 
 PLATFORMS
@@ -262,6 +267,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   etna
   factory_bot
@@ -274,6 +280,7 @@ DEPENDENCIES
   sequel (= 4.49.0)
   simplecov
   spreadsheet
+  timecop
 
 RUBY VERSION
    ruby 2.2.2p95


### PR DESCRIPTION
Since projects have loader code, they will inevitably accumulate external dependencies. Rather than adding them to the base magma Gemfile, this simply loads a Gemfile from each projects/whatever/ directory, so each project can define its own dependencies. Note this assumes that the project_path is projects/*, which may not be true depending on the individual config.yml.