### PR TITLE
Graft fix migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ config.yml
 *.gem
 *.swp
 
-/projects/ipi
+/projects

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,13 @@ group :test do
   gem 'simplecov'
   gem 'rack-test', require: "rack/test"
   gem 'factory_bot'
+  gem 'webmock'
   gem 'rspec'
   gem 'database_cleaner'
   gem 'pry'
   gem 'timecop'
+  gem 'net-http-persistent'
+  gem 'multipart-post'
 end
 
 Dir.glob File.expand_path("projects/*/Gemfile",__dir__) do |file|

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,17 @@ GEM
   remote: http://rubygems.org/
   specs:
     CFPropertyList (2.3.6)
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activesupport (5.2.0)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
-    carrierwave (1.2.2)
+    carrierwave (1.2.3)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -19,10 +21,13 @@ GEM
       sequel
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    curb (0.9.4)
+    connection_pool (2.2.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    curb (0.9.6)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
-    docile (1.3.0)
+    docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     etna (0.1.2)
@@ -31,7 +36,7 @@ GEM
       rack
     excon (0.62.0)
     extlib (0.9.16)
-    factory_bot (4.8.2)
+    factory_bot (4.11.0)
       activesupport (>= 3.0.0)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
@@ -70,9 +75,9 @@ GEM
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
       json (~> 2.0)
-    fog-aliyun (0.2.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
+    fog-aliyun (0.3.2)
+      fog-core
+      fog-json
       ipaddress (~> 0.8)
       xml-simple (~> 1.1)
     fog-atmos (0.1.0)
@@ -83,10 +88,11 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.14.0)
+    fog-brightbox (0.15.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
+      mime-types
     fog-cloudatcost (0.1.2)
       fog-core (~> 1.36)
       fog-json (~> 1.0)
@@ -96,10 +102,10 @@ GEM
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-digitalocean (0.3.0)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
+    fog-digitalocean (0.4.0)
+      fog-core
+      fog-json
+      fog-xml
       ipaddress (>= 0.5)
     fog-dnsimple (1.0.0)
       fog-core (~> 1.38)
@@ -122,29 +128,29 @@ GEM
     fog-joyent (0.0.1)
       fog-core (~> 1.42)
       fog-json (>= 1.0)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
+    fog-json (1.2.0)
+      fog-core
       multi_json (~> 1.10)
     fog-local (0.5.0)
       fog-core (>= 1.27, < 3.0)
-    fog-openstack (0.1.25)
-      fog-core (~> 1.40)
+    fog-openstack (0.2.0)
+      fog-core (~> 1.45.0)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
-    fog-ovirt (1.0.3)
-      fog-core (~> 1.45)
+    fog-ovirt (1.1.1)
+      fog-core
       fog-json
-      fog-xml (~> 0.1.1)
+      fog-xml
       ovirt-engine-sdk (>= 4.1.3)
       rbovirt (~> 0.1.5)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
+    fog-powerdns (0.2.0)
+      fog-core
+      fog-json
+      fog-xml
     fog-profitbricks (4.1.1)
       fog-core (~> 1.42)
       fog-json (~> 1.0)
-    fog-rackspace (0.1.5)
+    fog-rackspace (0.1.6)
       fog-core (>= 1.35)
       fog-json (>= 1.0)
       fog-xml (>= 0.1)
@@ -178,7 +184,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (2.1.1)
+    fog-vsphere (2.3.0)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -188,38 +194,43 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
+    hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
     ipaddress (0.8.3)
     json (2.1.0)
     jwt (2.1.0)
     method_source (0.9.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     mini_magick (4.8.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
     netrc (0.11.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     ovirt-engine-sdk (4.2.4)
       json (>= 1, < 3)
-    pg (1.0.0)
+    pg (1.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.3)
     rack (2.0.5)
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rbovirt (0.1.5)
+    rbovirt (0.1.7)
       nokogiri
       rest-client (> 1.7.0)
-    rbvmomi (1.12.0)
+    rbvmomi (1.13.0)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
@@ -228,36 +239,41 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     ruby-ole (1.2.12.1)
+    safe_yaml (1.0.4)
     sequel (4.49.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spreadsheet (1.1.7)
+    spreadsheet (1.1.8)
       ruby-ole (>= 1.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    trollop (2.1.2)
+    trollop (2.9.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xml-simple (1.1.5)
 
 PLATFORMS
@@ -273,6 +289,8 @@ DEPENDENCIES
   factory_bot
   fog
   mini_magick
+  multipart-post
+  net-http-persistent
   pg
   pry
   rack-test
@@ -281,6 +299,7 @@ DEPENDENCIES
   simplecov
   spreadsheet
   timecop
+  webmock
 
 RUBY VERSION
    ruby 2.2.2p95

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -41,10 +41,6 @@ class Magma
       json_for record
     end
 
-    def eager
-      nil
-    end
-
     def update(record, new_value)
       record.set({@name=> new_value})
     end
@@ -57,22 +53,6 @@ class Magma
       !@hide
     end
 
-    def tab_column?
-      shown?
-    end
-
-    def schema_ok?
-      schema.has_key?(column_name)
-    end
-
-    def schema_unchanged? 
-      schema[column_name][:db_type].to_sym == literal_type
-    end
-
-    def needs_column?
-      true
-    end
-
     def column_name
       @name
     end
@@ -80,14 +60,6 @@ class Magma
 
     def display_name
       @display_name || name.to_s.split(/_/).map(&:capitalize).join(' ')
-    end
-
-    def literal_type
-      if @type == DateTime
-        :"timestamp without time zone"
-      else
-        Magma.instance.db.cast_type_literal(@type)
-      end
     end
 
     def update_link(record, link)
@@ -110,10 +82,6 @@ class Magma
     end
 
     private
-
-    def schema
-      @model.schema
-    end
 
     def set_options(opts)
       opts.each do |opt,value|

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -1,7 +1,8 @@
 class Magma
   class Attribute
     DISPLAY_ONLY = [:child, :collection]
-    attr_reader(:name, :type, :desc, :loader, :match, :format_hint)
+    attr_reader :name, :type, :desc, :loader, :match, :format_hint, :unique, :index
+
 
     class << self
       def options
@@ -79,14 +80,6 @@ class Magma
 
     def display_name
       @display_name || name.to_s.split(/_/).map(&:capitalize).join(' ')
-    end
-
-    def migration(mig)
-      [ 
-        mig.column_entry(@name, type),
-        @unique && mig.unique_entry(@name),
-        @index && mig.index_entry(@name)
-      ].compact
     end
 
     def literal_type

--- a/lib/magma/attributes/child.rb
+++ b/lib/magma/attributes/child.rb
@@ -1,24 +1,8 @@
 class Magma
   class ChildAttribute < Attribute
     include Magma::Link
-    def schema_ok?
-      true
-    end
-
-    def schema_unchanged? 
-      true
-    end
-
-    def needs_column?
-      nil
-    end
-
     def json_for record
       record[@name]
-    end
-
-    def eager
-      @name
     end
 
     def update record, link

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -1,26 +1,6 @@
 class Magma
   class CollectionAttribute < Attribute
     include Magma::Link
-    def schema_ok?
-      true
-    end
-
-    def schema_unchanged? 
-      true
-    end
-
-    def needs_column?
-      nil
-    end
-
-    def tab_column?
-      nil
-    end
-
-    def eager
-      @name
-    end
-
     def json_for record
       link = record[@name]
       link ? link.map(&:last).sort : nil

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -5,10 +5,6 @@ class Magma
       @type = String
     end
 
-    def tab_column?
-      nil
-    end
-
     def update(record, new_value)
       super
       record.modified!(name)

--- a/lib/magma/attributes/foreign_key.rb
+++ b/lib/magma/attributes/foreign_key.rb
@@ -1,17 +1,8 @@
 class Magma
   class ForeignKeyAttribute < Attribute
     include Magma::Link
-
-    def schema_unchanged?
-      true
-    end
-
     def column_name
       foreign_id
-    end
-
-    def eager
-      @name
     end
 
     def json_for record

--- a/lib/magma/attributes/foreign_key.rb
+++ b/lib/magma/attributes/foreign_key.rb
@@ -2,19 +2,12 @@ class Magma
   class ForeignKeyAttribute < Attribute
     include Magma::Link
 
-    def schema_unchanged? 
+    def schema_unchanged?
       true
     end
 
     def column_name
       foreign_id
-    end
-
-    def migration mig
-      [
-        mig.foreign_key_entry(column_name, link_model),
-        mig.index_entry(column_name)
-      ]
     end
 
     def eager

--- a/lib/magma/attributes/foreign_key.rb
+++ b/lib/magma/attributes/foreign_key.rb
@@ -12,7 +12,7 @@ class Magma
 
     def migration mig
       [
-        mig.foreign_key_entry(column_name, link_model.table_name),
+        mig.foreign_key_entry(column_name, link_model),
         mig.index_entry(column_name)
       ]
     end

--- a/lib/magma/attributes/image.rb
+++ b/lib/magma/attributes/image.rb
@@ -5,10 +5,6 @@ class Magma
       @type = String
     end
 
-    def tab_column?
-      nil
-    end
-
     def update(record, new_value)
       super
       record.modified!(name)

--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -1,22 +1,6 @@
 class Magma
   class TableAttribute < Attribute
     include Magma::Link
-    def schema_ok?
-      true
-    end
-
-    def schema_unchanged? 
-      true
-    end
-
-    def needs_column?
-      nil
-    end
-
-    def tab_column?
-      nil
-    end
-
     def json_for record
       link = record[@name]
       link ? link.map(&:last) : nil
@@ -24,10 +8,6 @@ class Magma
 
     def txt_for record
       nil
-    end
-
-    def eager
-      @name
     end
 
     def update record, new_value

--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -55,7 +55,7 @@ class Magma
       puts <<EOT
 Sequel.migration do
   change do
-    #{Magma.instance.magma_projects.values.map(&:migrations).flatten.join("\n")}
+#{Magma.instance.magma_projects.values.map(&:migrations).flatten.join("\n")}
   end
 end
 EOT

--- a/lib/magma/loader.rb
+++ b/lib/magma/loader.rb
@@ -195,7 +195,7 @@ class Magma
 
     def records(model)
       return @records[model] if @records[model]
-      
+
       @records[model] = RecordSet.new(model, @validator, self)
       ensure_link_models(model)
 

--- a/lib/magma/migration.rb
+++ b/lib/magma/migration.rb
@@ -70,7 +70,7 @@ class Magma
     end
 
     def column_entry name, type
-      "#{type.name} :#{name}"
+      "#{type.respond_to?(:name) ? type.name : type} :#{name}"
     end
 
     def unique_entry name
@@ -105,7 +105,7 @@ class Magma
     end
 
     def column_entry name, type
-      "add_column :#{name}, #{type}"
+      "add_column :#{name}, #{type.is_a?(Symbol) ? ":#{type}" : type}"
     end
 
     def remove_column_entry name

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -1,4 +1,5 @@
 Sequel::Model.plugin :timestamps, update_on_create: true
+Sequel::Model.require_valid_table = false
 
 class Magma
   Model = Class.new(Sequel::Model)

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -12,8 +12,10 @@ class Magma
     def models
       @models ||= Hash[
         project_container.constants(false).map do |c|
-          project_container.const_get(c) 
-        end.select do |m| m < Magma::Model end.map do |m|
+          project_container.const_get(c)
+        end.select do |m|
+          m.is_a?(Class) && m < Magma::Model
+        end.map do |m|
           [ m.model_name, m ]
         end
       ]

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,16 +1,204 @@
 describe Magma::Migration do
-  before(:each) do
-    #allow(Magma.instance).to receive(:config).and_return(:default)
-    #allow(Magma.instance).to receive(:config).with(:project_path).and_return(:default)
+  context 'empty migrations' do
+    it 'does nothing if there is no change' do
+      migration = Labors::Project.migration
 
-    class Labors
-      class Olympian < Magma::Model
-        identifier :name
-      end
+      expect(migration).to be_empty
+      expect(migration.to_s).to eq('')
     end
   end
 
-  it 'suggests a migration' do
-    Olympian.migration
+  context 'creation migrations' do
+    after(:each) do
+      Labors.send(:remove_const, :Olympian)
+    end
+
+    it 'suggests a creation migration for identifiers' do
+      module Labors
+        class Olympian < Magma::Model
+          identifier :name, type: String
+        end
+      end
+      migration = Labors::Olympian.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    create_table(Sequel[:labors][:olympians]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      String :name
+      unique :name
+    end
+EOT
+    end
+
+    it 'suggests a creation migration for attributes' do
+      module Labors
+        class Olympian < Magma::Model
+          attribute :number, type: Integer
+        end
+      end
+      migration = Labors::Olympian.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    create_table(Sequel[:labors][:olympians]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      Integer :number
+    end
+EOT
+    end
+
+    it 'suggests a creation migration for json attributes' do
+      module Labors
+        class Olympian < Magma::Model
+          attribute :prayers, type: :json
+        end
+      end
+      migration = Labors::Olympian.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    create_table(Sequel[:labors][:olympians]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      json :prayers
+    end
+EOT
+    end
+
+    it 'suggests a creation migration for link attributes' do
+      module Labors
+        class Olympian < Magma::Model
+          parent :project
+
+          link :monster
+        end
+      end
+      migration = Labors::Olympian.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    create_table(Sequel[:labors][:olympians]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      foreign_key :project_id, Sequel[:labors][:projects]
+      index :project_id
+      foreign_key :monster_id, Sequel[:labors][:monsters]
+      index :monster_id
+    end
+EOT
+    end
+  end
+
+  context 'update migrations' do
+    def remove_attribute(model, attribute)
+      model.attributes.delete(attribute)
+      model.instance_variable_set("@identity",nil) if model.identity == attribute
+    end
+
+    it 'suggests an update migration for identifiers' do
+      module Labors
+        class Prize < Magma::Model
+          identifier :prize_code, type: String
+        end
+      end
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      add_column :prize_code, String
+      add_unique_constraint :prize_code
+    end
+EOT
+      remove_attribute(Labors::Prize, :prize_code)
+    end
+
+    it 'suggests an update migration for attributes' do
+      module Labors
+        class Prize < Magma::Model
+          attribute :weight, type: Float
+        end
+      end
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      add_column :weight, Float
+    end
+EOT
+      remove_attribute(Labors::Prize, :weight)
+    end
+
+    it 'suggests an update migration for json attributes' do
+      module Labors
+        class Prize < Magma::Model
+          attribute :dimensions, type: :json
+        end
+      end
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      add_column :dimensions, :json
+    end
+EOT
+      remove_attribute(Labors::Prize, :dimensions)
+    end
+
+    it 'suggests an update migration for link attributes' do
+      module Labors
+        class Prize < Magma::Model
+          link :monster
+        end
+      end
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      add_foreign_key :monster_id, Sequel[:labors][:monsters]
+      add_index :monster_id
+    end
+EOT
+      remove_attribute(Labors::Prize, :monster)
+    end
+    it 'removes attributes' do
+      worth = Labors::Prize.attributes[:worth]
+      remove_attribute(Labors::Prize,:worth)
+
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      drop_column :worth
+    end
+EOT
+      Labors::Prize.attributes[:worth] = worth
+    end
+
+    it 'makes multiple changes at once' do
+      worth = Labors::Prize.attributes[:worth]
+      remove_attribute(Labors::Prize,:worth)
+      module Labors
+        class Prize < Magma::Model
+          attribute :weight, type: Float
+        end
+      end
+
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      add_column :weight, Float
+      drop_column :worth
+    end
+EOT
+      remove_attribute(Labors::Prize, :weight)
+      Labors::Prize.attributes[:worth] = worth
+    end
+
+    it 'changes column types' do
+      worth = Labors::Prize.attributes[:worth]
+      worth.instance_variable_set("@type",Float)
+
+      migration = Labors::Prize.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      set_column_type :worth, Float
+    end
+EOT
+      worth.instance_variable_set("@type",Integer)
+    end
   end
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,9 +1,16 @@
 describe Magma::Migration do
   before(:each) do
-    allow(Magma.instance).to receive(:config).and_return(:default)
-    allow(Magma.instance).to receive(:config).with(:project_path).and_return(:default)
+    #allow(Magma.instance).to receive(:config).and_return(:default)
+    #allow(Magma.instance).to receive(:config).with(:project_path).and_return(:default)
+
+    class Labors
+      class Olympian < Magma::Model
+        identifier :name
+      end
+    end
   end
 
   it 'suggests a migration' do
+    Olympian.migration
   end
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -48,6 +48,23 @@ EOT
 EOT
     end
 
+    it 'suggests nothing in the creation for a table or collection attribute' do
+      module Labors
+        class Olympian < Magma::Model
+          collection :victim
+          table :prize
+        end
+      end
+      migration = Labors::Olympian.migration
+      expect(migration.to_s).to eq <<EOT.chomp
+    create_table(Sequel[:labors][:olympians]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+    end
+EOT
+    end
+
     it 'suggests a creation migration for json attributes' do
       module Labors
         class Olympian < Magma::Model
@@ -155,6 +172,7 @@ EOT
 EOT
       remove_attribute(Labors::Prize, :monster)
     end
+
     it 'removes attributes' do
       worth = Labors::Prize.attributes[:worth]
       remove_attribute(Labors::Prize,:worth)
@@ -166,6 +184,22 @@ EOT
     end
 EOT
       Labors::Prize.attributes[:worth] = worth
+    end
+
+    it 'makes no changes when removing child, collection or table attributes' do
+      monster = Labors::Labor.attributes[:monster]
+      prize = Labors::Labor.attributes[:prize]
+      victim = Labors::Monster.attributes[:victim]
+      remove_attribute(Labors::Labor,:monster)
+      remove_attribute(Labors::Labor,:prize)
+      remove_attribute(Labors::Monster,:victim)
+
+      expect(Labors::Labor.migration).to be_empty
+      expect(Labors::Monster.migration).to be_empty
+
+      Labors::Labor.attributes[:monster] = monster
+      Labors::Labor.attributes[:prize] = prize
+      Labors::Monster.attributes[:victim] = victim
     end
 
     it 'makes multiple changes at once' do

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,0 +1,9 @@
+describe Magma::Migration do
+  before(:each) do
+    allow(Magma.instance).to receive(:config).and_return(:default)
+    allow(Magma.instance).to receive(:config).with(:project_path).and_return(:default)
+  end
+
+  it 'suggests a migration' do
+  end
+end


### PR DESCRIPTION
This pull request cleans up a few migration-related issues regarding Sequel table aliases, deprecation warnings, migration formatting, and so on. This also adds a lot of tests to cover migration generation.

Magma is still pegged to run with Sequel 4.49 and does not seem to run with Sequel 5, which should be fixed at some point, but that doesn't happen here. Gemsets containing Sequel 5 might require using 'bundle exec' to run rspec tests.