### PR TITLE
fix pagination issue in retrieve

### DIFF
--- a/lib/magma/server/retrieve.rb
+++ b/lib/magma/server/retrieve.rb
@@ -100,7 +100,7 @@ class RetrieveController < Magma::Controller
         next if @attribute_names == 'identifier' && !model.has_identifier?
         retrieve_model(
           model, @record_names, @attribute_names,
-          [], false
+          [], true, false
         )
       end
     else
@@ -109,6 +109,7 @@ class RetrieveController < Magma::Controller
         @record_names,
         @attribute_names,
         [ Magma::Retrieval::StringFilter.new(@filter) ],
+        true,
         !@collapse_tables
       )
     end
@@ -134,15 +135,15 @@ class RetrieveController < Magma::Controller
     return [ 200, { 'Content-Type' => 'text/tsv' }, tsv_stream ]
   end
 
-  def retrieve_model(model, record_names, attribute_names, filters, get_tables=nil)
+  def retrieve_model(model, record_names, attribute_names, filters, use_pages, get_tables)
     # Extract the attributes from the model.
     retrieval = Magma::Retrieval.new(
       model,
       record_names,
       attribute_names,
       filters: filters,
-      page: get_tables && @page,
-      page_size: get_tables && @page_size,
+      page: use_pages && @page,
+      page_size: use_pages && @page_size,
       restrict: !@user.can_see_restricted?(@project_name)
     )
 
@@ -172,6 +173,7 @@ class RetrieveController < Magma::Controller
             records.map{|r| r[model.identity]}
           )
         ],
+        false,
         false
       )
     end

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -336,6 +336,21 @@ describe RetrieveController do
         page_size: 3
       )
 
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
+
+      # check to make sure collapse_tables doesn't mess things up
+      retrieve(
+        project_name: 'labors',
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: 'all',
+        collapse_tables: true,
+        page: 3,
+        page_size: 3
+      )
+
+      expect(last_response.status).to eq(200)
       expect(json_body[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
     end
 


### PR DESCRIPTION
At some point (due to a rather poorly-written interface in the function RetrieveController::retrieve_model) a regression was introduced when using the option collapse_tables (which removes table attributes from the results, used, e.g., by the Search page) that caused all pages to return instead of a specific page. This PR fixes that issue and adds a test to cover this case.