### PR TITLE
adjust model ordering in project migration

### DIFF
--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -21,8 +21,15 @@ class Magma
       ]
     end
 
+    def ordered_models(model)
+      link_models = model.attributes.values.select do |att|
+        att.is_a?(Magma::Link) && att.link_model.parent == model.model_name
+      end.map(&:link_model)
+      link_models + link_models.map{|m| ordered_models(m)}.flatten
+    end
+
     def migrations
-      models.values.map(&:migration).reject(&:empty?)
+      ([ models[:project] ] + ordered_models(models[:project])).map(&:migration).reject(&:empty?)
     end
 
     private


### PR DESCRIPTION
This is a fix to adjust the way tables are output when planning a migration.

The existing plan command outputs tables in some unspecified order - this can result in an initial migration which does not work, because a create_table may contain foreign keys to tables that do not exist yet.

This PR attempts to fix that by outputting tables in a breadth-first order based on parent models, to attempt to ensure that there are no foreign key conflicts. This doesn't prevent all situations from causing trouble (e.g. circular links between models), but it should do most of the time.