### PR TITLE
create_db command

### DIFF
--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -149,4 +149,56 @@ EOT
       Magma.instance.setup_db
     end
   end
+
+  class CreateDb < Etna::Command
+    usage '<project_name> # Attach an existing project to a magma instance, creating database and schema'
+
+    def execute(project_name)
+      @project_name = project_name
+      @project = Magma.instance.get_project(@project_name)
+      create_db if @no_db
+
+      suggest_create_project && exit unless @project
+
+      create_schema unless db_namespace?
+
+      puts "Database is setup. Please run `bin/magma migrate #{@project_name}`."
+    end
+
+    def suggest_create_project
+      puts <<EOT
+There is no project named #{@project_name} configured for Magma.
+Create the project repository (either with git clone
+or `magma create_project <project_name>`) and add
+the project path to the key :project_path in config.yml
+EOT
+    end
+
+    def db_namespace?
+      Magma.instance.db[ "SELECT 1 FROM pg_namespace WHERE nspname='#{@project_name}'" ].count > 0
+    end
+
+    def create_schema
+      puts "Creating namespace (schema) #{@project_name} in database #{@db_config[:database]}"
+
+      Magma.instance.db.run "CREATE SCHEMA #{@project_name}"
+    end
+
+    def create_db
+      # Create the database only
+
+      puts "Creating database #{@db_config[:database]}"
+      %x{ PGPASSWORD=#{@db_config[:password]} createdb -w -U #{@db_config[:user]} #{@db_config[:database]} }
+    end
+
+    def setup(config)
+      super
+      @db_config = Magma.instance.config(:db)
+      begin
+        Magma.instance.load_models(false)
+      rescue Sequel::DatabaseConnectionError
+        @no_db = true
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a 'create_db' command, which is a utility to attach a project to a magma instance.

There are several elements to setting up a complete project:
1) Correct database configuration
2) Project models and migrations
3) Data

This command provides (1). Given a config.yml containing a database name, user, and password which specify a valid postgres role, the create_db <project_name> command will ensure that the database exists and the schema for the specified project exists. Subsequently you can create or run migrations using an existing set of models.

If you previously created a database through postgres, you might have to change the owner of that database to the role in your config.yml in order to use this command, otherwise schema creation will not work.