### PR TITLE
fix table retrieval problem

### DIFF
--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -28,7 +28,8 @@ class Magma
     def attributes
       @attributes ||= begin
         attributes = @model.attributes.values.select do |att|
-          !att.is_a?(Magma::TableAttribute) && requested?(att) && !restricted?(att)
+          requested?(att) && !restricted?(att) &&
+          !(att.is_a?(Magma::TableAttribute) && @collapse_tables)
         end
 
         # if there is no identifier, use the :id column

--- a/lib/magma/server/retrieve.rb
+++ b/lib/magma/server/retrieve.rb
@@ -125,6 +125,7 @@ class RetrieveController < Magma::Controller
       @record_names,
       @attribute_names,
       filters: [ Magma::Retrieval::StringFilter.new(@filter) ],
+      collapse_tables: true,
       restrict: !@user.can_see_restricted?(@project_name)
     )
 
@@ -142,6 +143,7 @@ class RetrieveController < Magma::Controller
       record_names,
       attribute_names,
       filters: filters,
+      collapse_tables: @collapse_tables,
       page: use_pages && @page,
       page_size: use_pages && @page_size,
       restrict: !@user.can_see_restricted?(@project_name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,8 +63,8 @@ RSpec.configure do |config|
   original_stderr = $stderr
   original_stdout = $stdout
   config.before(:all) do
-    $stderr = File.open(File::NULL, "w")
-    $stdout = File.open(File::NULL, "w")
+    #$stderr = File.open(File::NULL, "w")
+    #$stdout = File.open(File::NULL, "w")
   end
   config.after(:all) do
     $stderr = original_stderr


### PR DESCRIPTION
Fixes another bug due to my poorly-written retrieval code with hard-to-follow logic. Somehow it was previously excluding all table attributes from display, rather than only excluding them if the 'collapse_tables' param to /retrieve is true. Fixed, along with tests to ensure this stays in place.