### PR TITLE
Graft fix query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,10 @@ gem 'etna'
 gem 'pg'
 gem 'sequel', '4.49.0'
 gem 'mini_magick'
+gem 'fog-aws'
 gem 'carrierwave-sequel'
 gem 'carrierwave'
 gem 'activesupport', '>= 4.2.6'
-gem 'fog'
 gem 'spreadsheet'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
-    activemodel (5.2.1)
-      activesupport (= 5.2.1)
-    activesupport (5.2.1)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
-    carrierwave (1.2.3)
+    carrierwave (1.3.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -20,224 +19,64 @@ GEM
       carrierwave
       sequel
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    curb (0.9.6)
+    curb (0.9.7)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
-    dry-inflector (0.1.2)
-    etna (0.1.3)
+    etna (0.1.4)
       jwt
       rack
     excon (0.62.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (2.0.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-ovirt
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (~> 2.0)
-    fog-aliyun (0.3.2)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (2.0.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
+    fog-aws (3.3.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.45.0)
+    fog-core (2.1.2)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-internet-archive (0.0.1)
-      fog-core
-      fog-json
-      fog-xml
-    fog-joyent (0.0.1)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
+      mime-types
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-local (0.6.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (0.3.6)
-      fog-core (>= 1.45, <= 2.1.0)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-ovirt (1.1.2)
-      fog-core
-      fog-json
-      fog-xml
-      ovirt-engine-sdk (>= 4.1.3)
-      rbovirt (~> 0.1.5)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (4.1.1)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (2.4.0)
-      fog-core
-      rbvmomi (~> 1.9)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    hashdiff (0.3.7)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    i18n (1.1.1)
+    hashdiff (0.3.8)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
     json (2.1.0)
     jwt (2.1.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mini_magick (4.9.2)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    netrc (0.11.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
-    ovirt-engine-sdk (4.2.5)
-      json (>= 1, < 3)
-    pg (1.1.3)
-    pry (0.11.3)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    pg (1.1.4)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rbovirt (0.1.7)
-      nokogiri
-      rest-client (> 1.7.0)
-    rbvmomi (1.13.0)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      trollop (~> 2.1)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -263,18 +102,12 @@ GEM
       ruby-ole (>= 1.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    trollop (2.9.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
-    webmock (3.4.2)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    xml-simple (1.1.5)
-    xmlrpc (0.3.0)
 
 PLATFORMS
   ruby
@@ -287,7 +120,7 @@ DEPENDENCIES
   database_cleaner
   etna
   factory_bot
-  fog
+  fog-aws
   mini_magick
   multipart-post
   net-http-persistent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,11 +23,11 @@ GEM
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    curb (0.9.7)
+    curb (0.9.8)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    etna (0.1.4)
+    etna (0.1.5)
       jwt
       rack
     excon (0.62.0)
@@ -98,7 +98,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spreadsheet (1.1.8)
+    spreadsheet (1.1.9)
       ruby-ole (>= 1.0)
     thread_safe (0.3.6)
     timecop (0.9.1)

--- a/lib/magma.rb
+++ b/lib/magma.rb
@@ -1,4 +1,8 @@
 require 'sequel'
+require 'fog/aws'
+require 'carrierwave/sequel'
+require 'carrierwave/storage/fog'
+
 require_relative 'magma/project'
 require_relative 'magma/validation'
 require_relative 'magma/loader'
@@ -11,6 +15,7 @@ require_relative 'magma/commands'
 require_relative 'magma/payload'
 require_relative 'magma/metric'
 require_relative 'magma/storage'
+
 require 'singleton'
 
 class Magma
@@ -118,6 +123,8 @@ class Magma
     return unless opts
     CarrierWave.tmp_path = Magma.instance.config(:tmp_path)
     CarrierWave.configure do |config|
+      config.storage :fog
+      config.fog_provider = 'fog/aws'
       config.fog_credentials = opts[:credentials]
       config.fog_directory = opts[:directory]
       config.fog_public = false

--- a/lib/magma/file_uploader.rb
+++ b/lib/magma/file_uploader.rb
@@ -1,6 +1,3 @@
-require 'fog'
-require 'carrierwave/sequel'
-require 'carrierwave/storage/fog'
 class Magma
   class FileUploader  < CarrierWave::Uploader::Base
     storage :fog

--- a/lib/magma/image_uploader.rb
+++ b/lib/magma/image_uploader.rb
@@ -1,6 +1,3 @@
-require 'fog'
-require 'carrierwave/sequel'
-
 class Magma
   class ImageUploader  < CarrierWave::Uploader::Base
     include CarrierWave::MiniMagick

--- a/lib/magma/query/constraint.rb
+++ b/lib/magma/query/constraint.rb
@@ -1,20 +1,14 @@
 class Magma
   class Constraint
-    attr_reader :conditions
+    attr_reader :conditions, :table_alias
 
-    def initialize(*args)
+    def initialize(table_alias, *args)
+      @table_alias = table_alias
       @conditions = args
     end
 
     def apply(query)
-      @inverted ?
-        query.exclude(*@conditions)
-      :
-        query.where(*@conditions)
-    end
-
-    def invert!
-      @inverted = true
+      query.where(*@conditions)
     end
 
     def to_s

--- a/lib/magma/query/join.rb
+++ b/lib/magma/query/join.rb
@@ -1,38 +1,50 @@
 class Magma
   class Join
-    def initialize(t1, t1_alias, t1_id, t2, t2_alias, t2_id)
-      @table1 = t1
-      @table1_alias = t1_alias.to_sym
-      @table1_id = t1_id.to_sym
-      @table2_alias = t2_alias.to_sym
-      @table2_id = t2_id.to_sym
+    attr_reader :constraints
+
+    attr_reader :right_table_alias, :left_table_alias
+
+    def initialize(lt, lt_alias, lt_id, rt, rt_alias, rt_id)
+      @right_table = rt
+      @right_table_alias = rt_alias.to_sym
+      @right_table_id = rt_id.to_sym
+
+      @left_table = lt
+      @left_table_alias = lt_alias.to_sym
+      @left_table_id = lt_id.to_sym
+
+      @constraints = [
+        { left_table_column => right_table_column }
+      ]
     end
 
     def apply query
       query.left_outer_join(
-        Sequel.as(@table1,@table1_alias),
-        table1_column => table2_column
+        Sequel.as(@right_table,@right_table_alias),
+        Sequel.&(
+          *@constraints
+        )
       )
     end
 
     def to_s
-      {table1_column=> table2_column}.to_s
+      @constraints.to_s
     end
 
-    def table1_column
-      Sequel.qualify(@table1_alias, @table1_id)
+    def right_table_column
+      Sequel.qualify(@right_table_alias, @right_table_id)
     end
 
-    def table2_column
-      Sequel.qualify(@table2_alias, @table2_id)
+    def left_table_column
+      Sequel.qualify(@left_table_alias, @left_table_id)
     end
 
     def hash
-      table1_column.hash + table2_column.hash
+      right_table_column.hash + left_table_column.hash
     end
 
     def eql?(other)
-      table1_column == other.table1_column && table2_column == other.table2_column
+      right_table_column == other.right_table_column && left_table_column == other.left_table_column
     end
   end
 end

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -193,6 +193,7 @@ class Magma
     # Some constraint helpers
     def comparison_constraint column_name, operator, value
       Magma::Constraint.new(
+        alias_name,
         Sequel.lit(
           "? #{operator.sub(/::/,'')} ?",
           Sequel.qualify(alias_name, column_name),
@@ -203,23 +204,25 @@ class Magma
 
     def not_null_constraint(column_name)
       Magma::Constraint.new(
-        Sequel.lit(
-          '? IS NOT NULL',
-          Sequel.qualify(alias_name, column_name)
+        alias_name,
+        Sequel.negate(
+          Sequel.qualify(alias_name, column_name) => nil
         )
       )
     end
 
     def not_constraint column_name, value
       Magma::Constraint.new(
-        Sequel.qualify(alias_name, column_name) => value
-      ).tap do |constraint|
-        constraint.invert!
-      end
+        alias_name,
+        Sequel.negate(
+          Sequel.qualify(alias_name, column_name) => value
+        )
+      )
     end
 
     def basic_constraint column_name, value
       Magma::Constraint.new(
+        alias_name,
         Sequel.qualify(alias_name, column_name) => value
       )
     end

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -95,21 +95,27 @@ class Magma
       case attribute
       when Magma::ForeignKeyAttribute
         return Magma::Join.new(
-          @child_predicate.table_name,
-          @child_predicate.alias_name,
-          :id,
+          # left table
           table_name,
           alias_name,
-          attribute.foreign_id
+          attribute.foreign_id,
+
+          #right table
+          @child_predicate.table_name,
+          @child_predicate.alias_name,
+          :id
         )
       when Magma::TableAttribute, Magma::CollectionAttribute, Magma::ChildAttribute
         return Magma::Join.new(
+          #left table
+          table_name,
+          alias_name,
+          :id,
+
+          #right table
           @child_predicate.table_name,
           @child_predicate.alias_name,
           attribute.self_id,
-          table_name,
-          alias_name,
-          :id
         )
       end
     end

--- a/lib/magma/query/question.rb
+++ b/lib/magma/query/question.rb
@@ -127,11 +127,14 @@ class Magma
         Sequel.as(@model.table_name, @start_predicate.alias_name)
       ).order(@start_predicate.identity)
 
-      predicate_collect(:join).uniq.each do |join|
+      joins = predicate_collect(:join).uniq
+      constraints = predicate_collect(:constraint).uniq
+
+      joins.each do |join|
         query = join.apply(query)
       end
 
-      predicate_collect(:constraint).uniq.each do |constraint|
+      constraints.each do |constraint|
         query = constraint.apply(query)
       end
 
@@ -147,11 +150,14 @@ class Magma
         Sequel.as(@model.table_name, @start_predicate.alias_name)
       ).order(@start_predicate.identity)
 
-      @start_predicate.join.uniq.each do |join|
+      joins = @start_predicate.join.uniq
+      constraints = @start_predicate.constraint.uniq
+
+      joins.each do |join|
         query = join.apply(query)
       end
 
-      @start_predicate.constraint.uniq.each do |constraint|
+      constraints.each do |constraint|
         query = constraint.apply(query)
       end
 

--- a/lib/magma/server/query.rb
+++ b/lib/magma/server/query.rb
@@ -4,19 +4,22 @@ require_relative '../query/question.rb'
 class QueryController < Magma::Controller
   def action
     return failure(401, errors: [ 'You are unauthorized' ]) unless @user && @user.can_view?(@project_name)
+
     begin
-      return success(Magma::Predicate.to_json, 'application/json') if @params[:query] == '::predicates'
+      if @params[:query] == '::predicates'
+        return success(Magma::Predicate.to_json, 'application/json')
+      end
       question = Magma::Question.new(@project_name, @params[:query],
                                      restrict: !@user.can_see_restricted?(@project_name),
                                      timeout: Magma.instance.config(:query_timeout))
       return_data = {answer: question.answer, type: question.type}
       return success(return_data.to_json, 'application/json')
     rescue ArgumentError => e
-      puts e.backtrace
+      Magma.instance.logger.log_error(e)
       return failure(422, errors: [ e.message ])
     rescue Sequel::DatabaseError => e
-      puts e.backtrace
-      return failure(501, errors: [ e.message ])
+      Magma.instance.logger.log_error(e)
+      return failure(501, errors: 'Database error.')
     end
   end
 end


### PR DESCRIPTION
This PR solves a bug in the /query API that removed some items from the response incorrectly, due to outer-joining tables on foreign key criterion (correctly producing rows with NULL values) but then applying filters to these rows in WHERE clauses (incorrectly remove rows with some NULL values). See discussion of the problem in #100 - the resolution was to move filtering criterion into the JOIN ON clause for mapped columns, but to keep those criterion in WHERE clauses for filters on the table.

The final result was incompatible with the current plot code, so this has been waiting on the completion of the timur branch `em-d3-v5`.