### PR TITLE
insert created_at and updated_at via update endpoint for new models

### DIFF
--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -22,9 +22,15 @@ class Magma
       new_links = added_links - existing_links
 
       if !new_links.empty?
+        now = DateTime.now
         link_model.multi_insert(
           new_links.map do |link|
-            { link_model.identity => link, self_id => record.id }
+            {
+              link_model.identity => link,
+              self_id => record.id,
+              created_at: now,
+              updated_at: now
+            }
           end
         )
       end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -41,6 +41,10 @@ describe UpdateController do
     expect(last_response.status).to eq(200)
     expect(Labors::Labor.count).to be(2)
     expect(json_body[:models][:project][:documents][:'The Two Labors of Hercules']).to eq(name: 'The Two Labors of Hercules', labor: [ 'Lernean Hydra', 'Nemean Lion' ])
+
+    # check that it sets created_at and updated_at
+    expect(Labors::Labor.select_map(:created_at)).to all( be_a(Time) )
+    expect(Labors::Labor.select_map(:updated_at)).to all( be_a(Time) )
   end
 
   it 'fails on validation checks' do


### PR DESCRIPTION
Apparently since April 2016 we have not been setting created_at or updated_at when we create new models; this data is thus all missing or out-of-date. This PR patches this error at least at the update endpoint level, although perhaps some NOT NULL constraints are in order to prevent this sort of thing more definitively.