### PR TITLE
Change attribute definitions

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -136,6 +136,5 @@ require_relative 'attributes/string_attribute'
 require_relative 'attributes/integer_attribute'
 require_relative 'attributes/boolean_attribute'
 require_relative 'attributes/date_time_attribute'
-require_relative 'attributes/json_attribute'
 require_relative 'attributes/float_attribute'
 

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -9,9 +9,8 @@ class Magma
 :format_hint, :loader, :link_model, :restricted ]
       end
 
-      def set_attribute(name, model, options, caller)
-        klass = "Magma::#{caller.to_s.capitalize}_attribute".camelcase.constantize
-        klass.new(name, model, options)
+      def set_attribute(name, model, options, attribute_class)
+        attribute_class.new(name, model, options)
       end
     end
 

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -3,11 +3,15 @@ class Magma
     DISPLAY_ONLY = [:child, :collection]
     attr_reader :name, :type, :desc, :loader, :match, :format_hint, :unique, :index, :restricted
 
-
     class << self
       def options
         [:type, :desc, :display_name, :hide, :readonly, :unique, :index, :match,
 :format_hint, :loader, :link_model, :restricted ]
+      end
+
+      def set_attribute(name, model, options, caller)
+        klass = "Magma::#{caller.to_s.capitalize}_attribute".camelcase.constantize
+        klass.new(name, model, options)
       end
     end
 
@@ -129,3 +133,10 @@ require_relative 'attributes/match'
 require_relative 'attributes/image'
 require_relative 'attributes/table'
 require_relative 'attributes/matrix'
+require_relative 'attributes/string_attribute'
+require_relative 'attributes/integer_attribute'
+require_relative 'attributes/boolean_attribute'
+require_relative 'attributes/date_time_attribute'
+require_relative 'attributes/json_attribute'
+require_relative 'attributes/float_attribute'
+

--- a/lib/magma/attributes/boolean_attribute.rb
+++ b/lib/magma/attributes/boolean_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class BooleanAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: TrueClass))
+    end
+  end
+end

--- a/lib/magma/attributes/child.rb
+++ b/lib/magma/attributes/child.rb
@@ -1,6 +1,11 @@
 class Magma
   class ChildAttribute < Attribute
     include Magma::Link
+    def initialize(name, model, opts)
+      model.one_to_one(name)
+      super
+    end
+
     def json_for record
       record[@name]
     end

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -1,6 +1,11 @@
 class Magma
   class CollectionAttribute < Attribute
     include Magma::Link
+    def initialize(name, model, opts)
+      model.one_to_many(name, class: model.project_model(name), primary_key: :id)
+      super
+    end
+    
     def json_for record
       link = record[@name]
       link ? link.map(&:last).sort : nil

--- a/lib/magma/attributes/date_time_attribute.rb
+++ b/lib/magma/attributes/date_time_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class DateTimeAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: DateTime))
+    end
+  end
+end

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,8 +1,9 @@
 class Magma
   class FileAttribute < Attribute
     def initialize(name, model, opts)
-      super
       @type = String
+      Magma.instance.storage.setup_uploader(model, name, :file) 
+      super
     end
 
     def update(record, new_value)

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -2,7 +2,8 @@ class Magma
   class FileAttribute < Attribute
     def initialize(name, model, opts)
       @type = String
-      Magma.instance.storage.setup_uploader(model, name, :file) 
+      file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
+      Magma.instance.storage.setup_uploader(model, name, file_type) 
       super
     end
 

--- a/lib/magma/attributes/float_attribute.rb
+++ b/lib/magma/attributes/float_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class FloatAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: Float))
+    end
+  end
+end

--- a/lib/magma/attributes/integer_attribute.rb
+++ b/lib/magma/attributes/integer_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class IntegerAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: Integer))
+    end
+  end
+end

--- a/lib/magma/attributes/json_attribute.rb
+++ b/lib/magma/attributes/json_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class JsonAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: :json))
+    end
+  end
+end

--- a/lib/magma/attributes/json_attribute.rb
+++ b/lib/magma/attributes/json_attribute.rb
@@ -1,7 +1,0 @@
-class Magma
-  class JsonAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: :json))
-    end
-  end
-end

--- a/lib/magma/attributes/match.rb
+++ b/lib/magma/attributes/match.rb
@@ -1,5 +1,10 @@
 class Magma
   class MatchAttribute < Attribute
+    def initialize(name, model, opts)
+      opts.merge!(type: :json)
+      super
+    end
+
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation
       def validate(value, &block)
         return if value.nil? || value.empty?

--- a/lib/magma/attributes/matrix.rb
+++ b/lib/magma/attributes/matrix.rb
@@ -2,6 +2,11 @@ require 'set'
 
 class Magma
   class MatrixAttribute < Attribute
+    def initialize(name, model, opts)
+      opts.merge!(type: :json)
+      super
+    end
+
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation
       def validate(value, &block)
         # nil is a valid value

--- a/lib/magma/attributes/string_attribute.rb
+++ b/lib/magma/attributes/string_attribute.rb
@@ -1,0 +1,7 @@
+class Magma
+  class StringAttribute < Attribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(type: String))
+    end
+  end
+end

--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -1,6 +1,11 @@
 class Magma
   class TableAttribute < Attribute
     include Magma::Link
+    def initialize(name, model, opts)
+      model.one_to_many(name, class: model.project_model(name), primary_key: :id)
+      super
+    end
+
     def json_for record
       link = record[@name]
       link ? link.map(&:last) : nil

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -8,19 +8,27 @@ class Magma
   class Model
     class << self
       def string(attribute_name, opts = {})
-        attribute(attribute_name, opts.merge(type: String))
+        _attribute(attribute_name, opts.merge(type: String))
       end
 
       def integer(attribute_name, opts = {})
-        attribute(attribute_name, opts.merge(type: Integer))
+        _attribute(attribute_name, opts.merge(type: Integer))
       end
 
       def boolean(attribute_name, opts = {})
-        attribute(attribute_name, opts.merge(type: Boolean))
+        _attribute(attribute_name, opts.merge(type: TrueClass))
       end
 
       def date_time(attribute_name, opts = {})
-        attributes(attribute_name, opts.merge(type: DateTime))
+        _attribute(attribute_name, opts.merge(type: DateTime))
+      end
+
+      def json(attribute_name, opts = {})
+        _attribute(attribute_name, opts.merge(type: :json))
+      end
+
+      def float(attribute_name, opts = {})
+        _attribute(attribute_name, opts.merge(type: Float))
       end
 
       def project_name
@@ -56,7 +64,7 @@ class Magma
 
       # identifier attribute, sets a unique identifier
       def identifier(name, opts)
-        attribute(name, opts.merge(unique: true))
+        _attribute(name, opts.merge(unique: true))
         @identity = name
 
         # Default ordering is by identifier.
@@ -76,7 +84,7 @@ class Magma
         if name
           @parent = name
           many_to_one name
-          attribute name, opts.merge(attribute_class: Magma::ForeignKeyAttribute)
+          _attribute name, opts.merge(attribute_class: Magma::ForeignKeyAttribute)
         end
         @parent
       end
@@ -84,52 +92,52 @@ class Magma
       # child attribute, links to a single child record
       def child(name, opts = {})
         one_to_one(name)
-        attribute(name, opts.merge(attribute_class: Magma::ChildAttribute))
+        _attribute(name, opts.merge(attribute_class: Magma::ChildAttribute))
       end
 
       # link attribute, links to a single other record
       def link(name, opts = {})
         many_to_one(name, class: project_model(opts[:link_model] || name))
-        attribute(name, opts.merge(attribute_class: Magma::ForeignKeyAttribute))
+        _attribute(name, opts.merge(attribute_class: Magma::ForeignKeyAttribute))
       end
 
       # file attribute, holds file data
       def file name, opts = {}
         Magma.instance.storage.setup_uploader(self, name, :file)
-        attribute name, opts.merge(attribute_class: Magma::FileAttribute)
+        _attribute name, opts.merge(attribute_class: Magma::FileAttribute)
       end
       alias_method :document, :file
 
       # image attribute, holds image data
       def image name, opts = {}
         Magma.instance.storage.setup_uploader(self, name, :image)
-        attribute name, opts.merge(attribute_class: Magma::ImageAttribute)
+        _attribute name, opts.merge(attribute_class: Magma::ImageAttribute)
       end
 
       # collection attribute, links to a collection by identifiers
       def collection(name, opts = {})
         one_to_many(name, class: project_model(name), primary_key: :id)
-        attribute(name, opts.merge(attribute_class: Magma::CollectionAttribute))
+        _attribute(name, opts.merge(attribute_class: Magma::CollectionAttribute))
       end
 
       # table attribute, links to a collection (table) with no identifier
       def table(name, opts = {})
         one_to_many(name, class: project_model(name), primary_key: :id)
-        attribute(name, opts.merge(attribute_class: Magma::TableAttribute))
+        _attribute(name, opts.merge(attribute_class: Magma::TableAttribute))
       end
 
       # match attribute, contains a json match object
       def match(name, opts = {})
-        attribute(name, opts.merge(attribute_class: Magma::MatchAttribute, type: :json))
+        _attribute(name, opts.merge(attribute_class: Magma::MatchAttribute, type: :json))
       end
 
       # matrix attribute, contains a row of data
       def matrix(name, opts = {})
-        attribute(name, opts.merge(attribute_class: Magma::MatrixAttribute, type: :json))
+        _attribute(name, opts.merge(attribute_class: Magma::MatrixAttribute, type: :json))
       end
 
       def restricted(opts= {})
-        attribute(:restricted, opts.merge(type: TrueClass))
+        _attribute(:restricted, opts.merge(type: TrueClass))
       end
 
       # suggests dictionary entries based on
@@ -249,14 +257,14 @@ class Magma
         )
 
         super
-        magma_model.send(:attribute, :created_at, type: DateTime, hide: true)
-        magma_model.send(:attribute, :updated_at, type: DateTime, hide: true)
+        magma_model.send(:_attribute, :created_at, type: DateTime, hide: true)
+        magma_model.send(:_attribute, :updated_at, type: DateTime, hide: true)
       end
 
       private
 
       # basic attribute, holds any pg data type
-      def attribute(attr_name, opts = {})
+      def _attribute(attr_name, opts = {})
         klass = opts.delete(:attribute_class) || Magma::Attribute
         attributes[attr_name] = klass.new(attr_name, self, opts)
       end

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -7,28 +7,10 @@ class Magma
    
   class Model
     class << self
-      def string(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: String))
-      end
-
-      def integer(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: Integer))
-      end
-
-      def boolean(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: TrueClass))
-      end
-
-      def date_time(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: DateTime))
-      end
-
-      def json(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: :json))
-      end
-
-      def float(attribute_name, opts = {})
-        _attribute(attribute_name, opts.merge(type: Float))
+      %i(string integer boolean date_time json float).each do |method_name|
+        define_method method_name do |attribute_name, opts={}|
+          attributes[attribute_name] = Magma::Attribute.set_attribute(attribute_name, self, opts, method_name)
+        end
       end
 
       def project_name

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -7,22 +7,10 @@ class Magma
    
   class Model
     class << self
-      %i(string integer boolean date_time json float file collection table match matrix child foreign_key).each do |method_name|
+      %i(string integer boolean date_time float file collection table match matrix child foreign_key).each do |method_name|
         define_method method_name do |attribute_name, opts={}|
-
-          case method_name
-          when :file, :image
-            Magma.instance.storage.setup_uploader(self, attribute_name, method_name) 
-          when :collection, :table
-            one_to_many(attribute_name, class: project_model(attribute_name), primary_key: :id)
-          when :match, :matrix
-            opts.merge!(type: :json)
-          when :child
-            one_to_one(attribute_name)
-          end
-
           klass = "Magma::#{method_name.to_s.capitalize}_attribute".camelcase.constantize
-          attributes[attribute_name] = Magma::Attribute.set_attribute(attribute_name, self, opts, klass)
+          attributes[attribute_name] = klass.new(attribute_name, self, opts)
         end
       end
 

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -7,7 +7,7 @@ class Magma
    
   class Model
     class << self
-      %i(string integer boolean date_time float file collection table match matrix child foreign_key).each do |method_name|
+      %i(string integer boolean date_time float file image collection table match matrix child foreign_key).each do |method_name|
         define_method method_name do |attribute_name, opts={}|
           klass = "Magma::#{method_name.to_s.capitalize}_attribute".camelcase.constantize
           attributes[attribute_name] = klass.new(attribute_name, self, opts)

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -4,8 +4,25 @@ Sequel.extension :inflector
 
 class Magma
   Model = Class.new(Sequel::Model)
+   
   class Model
     class << self
+      def string(attribute_name, opts = {})
+        attribute(attribute_name, opts.merge(type: String))
+      end
+
+      def integer(attribute_name, opts = {})
+        attribute(attribute_name, opts.merge(type: Integer))
+      end
+
+      def boolean(attribute_name, opts = {})
+        attribute(attribute_name, opts.merge(type: Boolean))
+      end
+
+      def date_time(attribute_name, opts = {})
+        attributes(attribute_name, opts.merge(type: DateTime))
+      end
+
       def project_name
         name.split('::').first.snake_case.to_sym
       end
@@ -31,12 +48,6 @@ class Magma
       # records and collections of records
       def attributes
         @attributes ||= {}
-      end
-
-      # basic attribute, holds any pg data type
-      def attribute(attr_name, opts = {})
-        klass = opts.delete(:attribute_class) || Magma::Attribute
-        attributes[attr_name] = klass.new(attr_name, self, opts)
       end
 
       def has_attribute?(name)
@@ -238,8 +249,16 @@ class Magma
         )
 
         super
-        magma_model.attribute(:created_at, type: DateTime, hide: true)
-        magma_model.attribute(:updated_at, type: DateTime, hide: true)
+        magma_model.send(:attribute, :created_at, type: DateTime, hide: true)
+        magma_model.send(:attribute, :updated_at, type: DateTime, hide: true)
+      end
+
+      private
+
+      # basic attribute, holds any pg data type
+      def attribute(attr_name, opts = {})
+        klass = opts.delete(:attribute_class) || Magma::Attribute
+        attributes[attr_name] = klass.new(attr_name, self, opts)
       end
     end
 

--- a/spec/labors/models/aspect.rb
+++ b/spec/labors/models/aspect.rb
@@ -10,10 +10,10 @@ module Labors
       value: :lore
 
     # the aspect in question
-    attribute :name, type: String
+    string :name
     # where the aspect is codified
-    attribute :source, type: String
+    string :source
     # the actual value
-    attribute :value, type: String
+    string :value
   end
 end

--- a/spec/labors/models/codex.rb
+++ b/spec/labors/models/codex.rb
@@ -2,9 +2,9 @@ module Labors
   class Codex < Magma::Model
     parent :project
 
-    attribute :monster, type: String
-    attribute :aspect, type: String
-    attribute :tome, type: String
+    string :monster
+    string :aspect
+    string :tome
     match :lore
   end
 end

--- a/spec/labors/models/labor.rb
+++ b/spec/labors/models/labor.rb
@@ -6,9 +6,9 @@ module Labors
 
     child :monster
 
-    attribute :number, type: Integer
-    attribute :completed, type: TrueClass
-    attribute :year, type: DateTime
+    integer :number
+    boolean :completed
+    date_time :year
 
     table :prize
 

--- a/spec/labors/models/monster.rb
+++ b/spec/labors/models/monster.rb
@@ -3,7 +3,7 @@ module Labors
     parent :labor
 
     identifier :name, type: String
-    attribute :species, type: String, match: /^[a-z\s]+$/
+    string :species, match: /^[a-z\s]+$/
     collection :victim
     table :aspect
     file :stats

--- a/spec/labors/models/prize.rb
+++ b/spec/labors/models/prize.rb
@@ -2,7 +2,9 @@ module Labors
   class Prize < Magma::Model
     parent :labor
 
-    attribute :name, type: String
-    attribute :worth, type: Integer
+    string :name
+    integer :worth
   end
 end
+
+

--- a/spec/labors/models/victim.rb
+++ b/spec/labors/models/victim.rb
@@ -5,6 +5,6 @@ module Labors
     restricted
 
     identifier :name, type: String
-    attribute :country, type: String, restricted: true
+    string :country, restricted: true
   end
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -68,7 +68,7 @@ EOT
     it 'suggests a creation migration for json attributes' do
       module Labors
         class Olympian < Magma::Model
-          json :prayers
+          match :prayers
         end
       end
       migration = Labors::Olympian.migration
@@ -146,7 +146,7 @@ EOT
     it 'suggests an update migration for json attributes' do
       module Labors
         class Prize < Magma::Model
-          json :dimensions
+          match :dimensions
         end
       end
       migration = Labors::Prize.migration

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -34,7 +34,7 @@ EOT
     it 'suggests a creation migration for attributes' do
       module Labors
         class Olympian < Magma::Model
-          attribute :number, type: Integer
+          integer :number
         end
       end
       migration = Labors::Olympian.migration
@@ -68,7 +68,7 @@ EOT
     it 'suggests a creation migration for json attributes' do
       module Labors
         class Olympian < Magma::Model
-          attribute :prayers, type: :json
+          json :prayers
         end
       end
       migration = Labors::Olympian.migration
@@ -131,7 +131,7 @@ EOT
     it 'suggests an update migration for attributes' do
       module Labors
         class Prize < Magma::Model
-          attribute :weight, type: Float
+          float :weight
         end
       end
       migration = Labors::Prize.migration
@@ -146,7 +146,7 @@ EOT
     it 'suggests an update migration for json attributes' do
       module Labors
         class Prize < Magma::Model
-          attribute :dimensions, type: :json
+          json :dimensions
         end
       end
       migration = Labors::Prize.migration
@@ -208,7 +208,7 @@ EOT
       remove_attribute(Labors::Prize,:worth)
       module Labors
         class Prize < Magma::Model
-          attribute :weight, type: Float
+          float :weight
         end
       end
 

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -189,7 +189,7 @@ describe RetrieveController do
       project_doc = json_body[:models][:project][:documents][project.name.to_sym]
 
       expect(project_doc).not_to be_nil
-      expect(project_doc[:labor]).to eq(labors.map(&:name))
+      expect(project_doc[:labor]).to match_array(labors.map(&:name))
     end
 
     it 'returns an empty list for empty collections' do
@@ -402,7 +402,7 @@ describe RetrieveController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
-      expect(json_body[:models][:labor][:documents][labor_list[7][:name].to_sym][:prize]).to eq(prize_list.map(&:id))
+      expect(json_body[:models][:labor][:documents][labor_list[7][:name].to_sym][:prize]).to match_array(prize_list.map(&:id))
 
       # check to make sure collapse_tables doesn't mess things up
       retrieve(

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -136,8 +136,8 @@ describe RetrieveController do
       json = json_body
 
       # any model with an identifier returns all records
-      expect(json[:models][:labor][:documents].keys).to eq(labors.map(&:name).map(&:to_sym))
-      expect(json[:models][:monster][:documents].keys).to eq(monsters.map(&:name).map(&:to_sym))
+      expect(json[:models][:labor][:documents].keys).to match(labors.map(&:name).map(&:to_sym))
+      expect(json[:models][:monster][:documents].keys).to match(monsters.map(&:name).map(&:to_sym))
 
       # it does not return a model with no identifier
       expect(json[:models][:prize]).to be_nil
@@ -358,7 +358,7 @@ describe RetrieveController do
       expect(last_response.status).to eq(200)
 
       labor_names = json_body[:models][:labor][:documents].values.map{|d| d[:name]}
-      expect(labor_names).to eq(new_labors.map(&:name))
+      expect(labor_names).to match(new_labors.map(&:name))
     end
 
     it 'can filter on updated_at, created_at' do
@@ -379,7 +379,7 @@ describe RetrieveController do
       expect(last_response.status).to eq(200)
 
       labor_names = json_body[:models][:labor][:documents].values.map{|d| d[:name]}
-      expect(labor_names).to eq(new_labors.map(&:name))
+      expect(labor_names).to match(new_labors.map(&:name))
 
       Timecop.return
     end


### PR DESCRIPTION
#113 

This will start work on the linked ticket. It will make the `#attribute` method private within the `model` class and allow for attribute creation by using `data_type :attribute_name` where the allowed data_types are `string`, `integer`, `boolean`, and `date_time`.