### PR TITLE
Refactor attribute_child method to not use types

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class Attribute
     DISPLAY_ONLY = [:child, :collection]
-    attr_reader :name, :type, :desc, :loader, :match, :format_hint, :unique, :index, :restricted
+    attr_reader :name, :desc, :loader, :match, :format_hint, :unique, :index, :restricted
 
     class << self
       def options
@@ -18,6 +18,10 @@ class Magma
       @name = name
       @model = model
       set_options(opts)
+    end
+
+    def _type
+      @type
     end
 
     def json_template

--- a/lib/magma/migration.rb
+++ b/lib/magma/migration.rb
@@ -50,7 +50,7 @@ class Magma
         ]
       when Magma::Attribute
         [
-          column_entry(att.column_name, att.type),
+          column_entry(att.column_name, att._type),
           att.unique && unique_entry(att.column_name),
           att.index && index_entry(att.column_name)
         ].compact
@@ -82,8 +82,8 @@ class Magma
       # neither can foreign keys change their type
       return true if att.is_a?(Magma::ForeignKeyAttribute)
 
-      literal_type = att.type == DateTime ?  :"timestamp without time zone" :
-        Magma.instance.db.cast_type_literal(att.type)
+      literal_type = att.is_a?(DateTimeAttribute)?  :"timestamp without time zone" :
+        Magma.instance.db.cast_type_literal(att._type)
 
       return model.schema[att.column_name][:db_type].to_sym == literal_type.to_sym
     end
@@ -181,7 +181,7 @@ class Magma
       @model.attributes.map do |name,att|
         next unless schema_supports_attribute?(@model,att)
         next if schema_unchanged?(@model,att)
-        column_type_entry(att.column_name, att.type)
+        column_type_entry(att.column_name, att._type)
       end.compact.flatten
     end
 

--- a/lib/magma/query/predicate/record.rb
+++ b/lib/magma/query/predicate/record.rb
@@ -138,19 +138,16 @@ class Magma
         return Magma::MatchPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
       when Magma::MatrixAttribute
         return Magma::MatrixPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
+      when Magma::StringAttribute
+        return Magma::StringPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
+      when Magma::IntegerAttribute, Magma::FloatAttribute
+        return Magma::NumberPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
+      when Magma::DateTimeAttribute
+        return Magma::DateTimePredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
+      when Magma::BooleanAttribute
+        return Magma::BooleanPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
       else
-        case attribute.type.to_s
-        when 'String'
-          return Magma::StringPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
-        when 'Integer', 'Float'
-          return Magma::NumberPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
-        when 'DateTime'
-          return Magma::DateTimePredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
-        when 'TrueClass'
-          return Magma::BooleanPredicate.new(@question, @model, alias_name, attribute.name, *@query_args)
-        else
-          invalid_argument! attribute.name
-        end
+        invalid_argument! attribute.name
       end
     end
 

--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -167,25 +167,19 @@ class Magma
 
         att = attributes.find{|a| a.name == att_name.to_sym}
         raise ArgumentError, "#{att_name} is not an attribute" unless att.is_a?(Magma::Attribute)
-
         case att
         when Magma::CollectionAttribute, Magma::TableAttribute
           raise ArgumentError, "Cannot filter on collection attributes"
         when Magma::ForeignKeyAttribute, Magma::ChildAttribute
           return [ att_name, '::identifier', string_op(operator), value ]
-        when Magma::Attribute
-          case att._type.name
-          when "Integer", "Float"
-            return [ att_name, numeric_op(operator), value.to_f ]
-          when "DateTime"
-            return [ att_name, numeric_op(operator), value ]
-          when "String"
-            return [ att_name, string_op(operator), value ]
-          when "TrueClass"
-            return [ att_name, boolean_op(operator, value) ]
-          else
-            raise ArgumentError, "Unknown type for attribute"
-          end
+        when Magma::IntegerAttribute, Magma::FloatAttribute
+          return [ att_name, numeric_op(operator), value.to_f ]
+        when Magma::DateTimeAttribute
+          return [ att_name, numeric_op(operator), value ]
+        when Magma::StringAttribute
+          return [ att_name, string_op(operator), value ]
+        when Magma::BooleanAttribute
+          return [ att_name, boolean_op(operator, value) ]
         else
           raise ArgumentError, "Cannot query for #{att_name}"
         end

--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -174,7 +174,7 @@ class Magma
         when Magma::ForeignKeyAttribute, Magma::ChildAttribute
           return [ att_name, '::identifier', string_op(operator), value ]
         when Magma::Attribute
-          case att.type.name
+          case att._type.name
           when "Integer", "Float"
             return [ att_name, numeric_op(operator), value.to_f ]
           when "DateTime"


### PR DESCRIPTION
#113 

Refactor `#attribute_child` method to use new attribute classes.