### PR TITLE
Graft fix matrix slice

### DIFF
--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -134,6 +134,8 @@ class Magma
     def process_args(query_args)
       @verb, @arguments, @query_args = self.class.match_verbs(query_args, self)
 
+      @verb.do(:validate,@arguments)
+
       @child_predicate = @verb.do(:child)
     end
 

--- a/lib/magma/query/predicate.rb
+++ b/lib/magma/query/predicate.rb
@@ -166,7 +166,7 @@ class Magma
           end
         end
 
-        # this will raise an ArgumentError
+        # this will raise a QuestionError
         predicate.send(:invalid_argument!,query_args.first) if matching_args.nil?
 
         return [
@@ -244,12 +244,12 @@ class Magma
     end
 
     def invalid_argument! argument
-      raise ArgumentError, "Expected an argument to #{self.class.name}" if argument.nil?
-      raise ArgumentError, "#{argument} is not a valid argument to #{self.class.name}"
+      raise QuestionError, "Expected an argument to #{self.class.name}" if argument.nil?
+      raise QuestionError, "#{argument} is not a valid argument to #{self.class.name}"
     end
 
     def terminal value
-      raise ArgumentError, 'Trailing arguments after terminal value!' unless @query_args.empty?
+      raise QuestionError, 'Trailing arguments after terminal value!' unless @query_args.empty?
       Magma::TerminalPredicate.new(@question, value)
     end
   end

--- a/lib/magma/query/predicate/matrix.rb
+++ b/lib/magma/query/predicate/matrix.rb
@@ -2,6 +2,7 @@ require 'set'
 
 class Magma
   class MatrixPredicate < Magma::Predicate
+    attr_reader :attribute
     def initialize question, model, alias_name, attribute_name, *query_args
       super(question)
       @model = model
@@ -18,6 +19,9 @@ class Magma
       extract do |table, identity|
         @requested_identifiers << table.first[identity]
         MatrixValue.new(self, table.first[identity], @arguments[1])
+      end
+      validate do |_, match_list|
+        (match_list - @predicate.attribute.match).empty? && !match_list.empty?
       end
       format { [ default_format, @arguments[1] ] }
     end

--- a/lib/magma/query/question.rb
+++ b/lib/magma/query/question.rb
@@ -43,6 +43,8 @@ require_relative 'query_executor'
 # [ "sample", [ "sample_name", "::matches", "Sample[4-5]" ], "::all", "patient", "experiment", "name" ]
 
 class Magma
+  class QuestionError < StandardError
+  end
   class Question
     def initialize(project_name, query_args, options = {})
       @model = Magma.instance.get_model(project_name, query_args.shift)
@@ -172,7 +174,7 @@ class Magma
 
     # get page bounds for this question using @options[:page] and @options[:page_size]
     def bounds_query
-      raise ArgumentError, 'Page size must be greater than 1' unless @options[:page_size] > 1
+      raise QuestionError, 'Page size must be greater than 1' unless @options[:page_size] > 1
       count_query.from_self.select(
         # add row_numbers to the count query
         @start_predicate.identity,
@@ -229,11 +231,11 @@ class Magma
     end
 
     def paged_query(query)
-      raise ArgumentError, 'Page must start at 1' unless @options[:page] > 0
+      raise QuestionError, 'Page must start at 1' unless @options[:page] > 0
       bounds = to_table(page_bounds_query).map do |row|
         row[@start_predicate.identity]
       end
-      raise ArgumentError, "Page #{@options[:page]} not found" if bounds.empty?
+      raise QuestionError, "Page #{@options[:page]} not found" if bounds.empty?
 
       apply_bounds(query, bounds[0], bounds[1])
     end

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -87,6 +87,16 @@ class Magma
       @format = block_given? ? block : args
     end
 
+    def validate(&block)
+      @validate = block_given? ? block : nil
+    end
+
+    def get_validate(arguments)
+      if @validate && !@validate.call(arguments)
+        raise QuestionError, "Invalid verb arguments #{arguments.join(', ')}"
+      end
+    end
+
     def get_format(*args)
       @predicate.instance_exec(*args, &@format)
     end

--- a/lib/magma/query/verb.rb
+++ b/lib/magma/query/verb.rb
@@ -11,7 +11,7 @@ class Magma
       if respond_to?(:"get_#{action}", true)
         send :"get_#{action}", *args
       else
-        raise ArgumentError, "Verb for #{@predicate} cannot do #{action}"
+        raise "Verb for #{@predicate} cannot do #{action}"
       end
     end
 
@@ -42,7 +42,7 @@ class Magma
       when Class
         @predicate.send :terminal, @child
       else
-        raise ArgumentError, "Cannot determine child_predicate for #{@predicate}"
+        raise "Cannot determine child_predicate for #{@predicate}"
       end
     end
 
@@ -57,7 +57,7 @@ class Magma
       when Proc
         @predicate.instance_exec(&@join)
       else
-        raise ArgumentError, "Cannot determine join for #{@predicate}"
+        raise "Cannot determine join for #{@predicate}"
       end
     end
 
@@ -72,7 +72,7 @@ class Magma
       when Proc
         @predicate.instance_exec(&@constraint)
       else
-        raise ArgumentError, "Cannot determine constraint for #{@predicate}"
+        raise "Cannot determine constraint for #{@predicate}"
       end
     end
     def extract(*args, &block)

--- a/lib/magma/server/query.rb
+++ b/lib/magma/server/query.rb
@@ -14,8 +14,7 @@ class QueryController < Magma::Controller
                                      timeout: Magma.instance.config(:query_timeout))
       return_data = {answer: question.answer, type: question.type, format: question.format}
       return success(return_data.to_json, 'application/json')
-    rescue ArgumentError => e
-      Magma.instance.logger.log_error(e)
+    rescue Magma::QuestionError => e
       return failure(422, errors: [ e.message ])
     rescue Sequel::DatabaseError => e
       Magma.instance.logger.log_error(e)


### PR DESCRIPTION
While poking around in Magma::MatrixAttribute to try and figure out #119, I discovered that the '::slice' verb to the Magma::MatrixPredicate behaves poorly (i.e., 500s) with invalid arguments. Normally the argument to slice should be an array of strings mapping to the column names associated with the matrix attribute (e.g. `[ ..., 'matrix', '::slice', [ 'GENE1', 'GENE2' ] ]`). The list of valid column names is currently shoved into the match parameter of the matrix attribute; if the arguments to the column name are invalid, Magma errors when trying to extract the slice. Instead, it should return a 422 to the user with some instructions on what to fix.

To support this, this PR does two things:
1) A validation interface is added to `Magma::Verb`. This allows the verb to examine the arguments given to it when instantiated and check whether they are invalid. This new interface is only in use in the MatrixPredicate, although it could probably be made use of in other places (e.g. the RecordPredicate), perhaps everywhere we do any argument checking for any predicate.

2) The error needs to raise back to the user and give a 422; to facilitate this I replaced raising of ArgumentError (which was ambiguous as to who caused the error) with a QuestionError class which is caught in the controller and packaged as a 422.