### PR TITLE
Remove attribute usage in example proejct models

### DIFF
--- a/projects/example/models/example_patient.rb
+++ b/projects/example/models/example_patient.rb
@@ -1,10 +1,8 @@
 module Example
   class ExamplePatient < Magma::Model
-    attribute :notes,
-      type: String,
+    string :notes,
       desc: 'General notes about this patient.'
-    attribute :physician, 
-      type: String, 
+    string :physician,
       desc: 'The contact info for a patient\'s doctor.'
   end
 end

--- a/projects/example/models/example_project.rb
+++ b/projects/example/models/example_project.rb
@@ -1,7 +1,6 @@
 module Example
   class ExampleProject < Magma::Model
-    attribute :description,
-      type: String
+    string :description
     identifier :name,
       type:String,
       desc: 'A name for this project.'


### PR DESCRIPTION
Per https://github.com/mountetna/magma/pull/118, attribute is no longer available in `Magma::Model`s.