### PR TITLE
Make chosen attribute options editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Here is an example Magma model:
 
     module Pancan
       class Sample < Magma::Model
-        identifier :name, desc: 'PANCAN id'
-        attribute :mass, type: Float, desc: 'Mass in grams'
+        identifier :name, description: 'PANCAN id'
+        attribute :mass, type: Float, description: 'Mass in grams'
       end
     end
 

--- a/db/migrations/001_add_attributes.rb
+++ b/db/migrations/001_add_attributes.rb
@@ -6,7 +6,6 @@ Sequel.migration do
       String :attribute_name
       String :desc
       String :display_name
-      String :match
       String :format_hint
       DateTime :created_at
       DateTime :updated_at

--- a/db/migrations/001_add_attributes.rb
+++ b/db/migrations/001_add_attributes.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  change do
+    create_table(:attributes) do
+      String :project_name
+      String :model_name
+      String :attribute_name
+      String :desc
+      String :display_name
+      String :match
+      String :format_hint
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end

--- a/db/migrations/001_add_attributes.rb
+++ b/db/migrations/001_add_attributes.rb
@@ -4,7 +4,7 @@ Sequel.migration do
       String :project_name
       String :model_name
       String :attribute_name
-      String :desc
+      String :description
       String :display_name
       String :format_hint
       DateTime :created_at

--- a/db/migrations/001_add_attributes.rb
+++ b/db/migrations/001_add_attributes.rb
@@ -10,6 +10,8 @@ Sequel.migration do
       String :format_hint
       DateTime :created_at
       DateTime :updated_at
+
+      index [:project_name, :model_name, :attribute_name], unique: true
     end
   end
 end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -1,6 +1,8 @@
 class Magma
   class Attribute
     DISPLAY_ONLY = [:child, :collection]
+    EDITABLE_OPTIONS = [:desc, :display_name, :format_hint]
+
     attr_reader :name, :desc, :loader, :match, :format_hint, :unique, :index, :restricted
 
     class << self
@@ -95,6 +97,7 @@ class Magma
 
     def update_option(opt, new_value)
       opt = opt.to_sym
+      return unless EDITABLE_OPTIONS.include?(opt)
 
       Magma.instance.db[:attributes].
         insert_conflict(
@@ -109,7 +112,6 @@ class Magma
           "#{opt}": new_value
         )
 
-      new_value = Regexp.new(new_value) if opt == :match
       instance_variable_set("@#{opt}", new_value)
     end
 
@@ -125,7 +127,7 @@ class Magma
     end
 
     def fetch_value(opt)
-      return unless [:desc, :display_name, :match, :format_hint].include?(opt)
+      return unless EDITABLE_OPTIONS.include?(opt)
 
       Magma.instance.db[:attributes].
         select(opt).

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -94,12 +94,16 @@ class Magma
     def update_option(opt, new_value)
       opt = opt.to_sym
 
-      Magma.instance.db[:attributes].insert(
-        project_name: @model.project_name.to_s,
-        model_name: @model.model_name.to_s,
-        attribute_name: name.to_s,
-        "#{opt}": new_value
-      )
+      Magma.instance.db[:attributes].
+        insert_conflict(
+          target: [:project_name, :model_name, :attribute_name],
+          update: { "#{opt}": new_value }
+        ).insert(
+          project_name: @model.project_name.to_s,
+          model_name: @model.model_name.to_s,
+          attribute_name: name.to_s,
+          "#{opt}": new_value
+        )
 
       new_value = Regexp.new(new_value) if opt == :match
       instance_variable_set("@#{opt}", new_value)

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -3,12 +3,12 @@ class Magma
     DISPLAY_ONLY = [:child, :collection]
     EDITABLE_OPTIONS = [:description, :display_name, :format_hint]
 
-    attr_reader :name, :description, :loader, :match, :format_hint, :unique, :index, :restricted
+    attr_reader :name, :loader, :match, :format_hint, :unique, :index, :restricted
 
     class << self
       def options
         [:type, :description, :display_name, :hide, :readonly, :unique, :index, :match,
-:format_hint, :loader, :link_model, :restricted ]
+:format_hint, :loader, :link_model, :restricted, :desc ]
       end
 
       def set_attribute(name, model, options, attribute_class)
@@ -32,7 +32,7 @@ class Magma
         model_name: self.is_a?(Magma::Link) ? link_model.model_name : nil,
         type: @type.nil? ? nil : @type.respond_to?(:name) ? @type.name : @type,
         attribute_class: self.class.name,
-        desc: @description,
+        desc: description,
         display_name: display_name,
         options: @match.is_a?(Array) ? @match : nil,
         match: @match.is_a?(Regexp) ? @match.source : nil,
@@ -82,6 +82,10 @@ class Magma
       @display_name ||= (
         fetch_value(:display_name) || name.to_s.split(/_/).map(&:capitalize).join(' ')
       )
+    end
+
+    def description
+      @description || @desc
     end
 
     def update_link(record, link)

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -1,13 +1,13 @@
 class Magma
   class Attribute
     DISPLAY_ONLY = [:child, :collection]
-    EDITABLE_OPTIONS = [:desc, :display_name, :format_hint]
+    EDITABLE_OPTIONS = [:description, :display_name, :format_hint]
 
-    attr_reader :name, :desc, :loader, :match, :format_hint, :unique, :index, :restricted
+    attr_reader :name, :description, :loader, :match, :format_hint, :unique, :index, :restricted
 
     class << self
       def options
-        [:type, :desc, :display_name, :hide, :readonly, :unique, :index, :match,
+        [:type, :description, :display_name, :hide, :readonly, :unique, :index, :match,
 :format_hint, :loader, :link_model, :restricted ]
       end
 
@@ -32,7 +32,7 @@ class Magma
         model_name: self.is_a?(Magma::Link) ? link_model.model_name : nil,
         type: @type.nil? ? nil : @type.respond_to?(:name) ? @type.name : @type,
         attribute_class: self.class.name,
-        desc: @desc,
+        desc: @description,
         display_name: display_name,
         options: @match.is_a?(Array) ? @match : nil,
         match: @match.is_a?(Regexp) ? @match.source : nil,

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -77,7 +77,9 @@ class Magma
 
 
     def display_name
-      @display_name || name.to_s.split(/_/).map(&:capitalize).join(' ')
+      @display_name ||= (
+        fetch_value(:display_name) || name.to_s.split(/_/).map(&:capitalize).join(' ')
+      )
     end
 
     def update_link(record, link)

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -97,11 +97,13 @@ class Magma
       Magma.instance.db[:attributes].
         insert_conflict(
           target: [:project_name, :model_name, :attribute_name],
-          update: { "#{opt}": new_value }
+          update: { "#{opt}": new_value, updated_at: Time.now }
         ).insert(
           project_name: @model.project_name.to_s,
           model_name: @model.model_name.to_s,
           attribute_name: name.to_s,
+          created_at: Time.now,
+          updated_at: Time.now,
           "#{opt}": new_value
         )
 

--- a/lib/magma/commands.rb
+++ b/lib/magma/commands.rb
@@ -38,6 +38,28 @@ class Magma
     end
   end
 
+  class GlobalMigrate < Etna::Command
+    usage "Run database wide migrations"
+
+    def execute(version = nil)
+      Sequel.extension(:migration)
+      db = Magma.instance.db
+
+      if version
+        puts "Migrating to version #{version}"
+        Sequel::Migrator.run(db, File.join("db", "migrations"), target: version.to_i)
+      else
+        puts 'Migrating to latest'
+        Sequel::Migrator.run(db, File.join("db", "migrations"))
+      end
+    end
+
+    def setup(config)
+      super
+      Magma.instance.setup_db
+    end
+  end
+
   # When building migrations from scratch this command does not output
   # an order that respects foreign key constraints. i.e. The order in which the
   # migration creates tries to create the tables is out of whack and causes 

--- a/projects/example/models/example_patient.rb
+++ b/projects/example/models/example_patient.rb
@@ -1,8 +1,8 @@
 module Example
   class ExamplePatient < Magma::Model
     string :notes,
-      desc: 'General notes about this patient.'
+      description: 'General notes about this patient.'
     string :physician,
-      desc: 'The contact info for a patient\'s doctor.'
+      description: 'The contact info for a patient\'s doctor.'
   end
 end

--- a/projects/example/models/example_project.rb
+++ b/projects/example/models/example_project.rb
@@ -3,6 +3,6 @@ module Example
     string :description
     identifier :name,
       type:String,
-      desc: 'A name for this project.'
+      description: 'A name for this project.'
   end
 end

--- a/spec/labors/models/project.rb
+++ b/spec/labors/models/project.rb
@@ -1,6 +1,6 @@
 module Labors
   class Project < Magma::Model
-    identifier :name, type: String, desc: 'Name for this project'
+    identifier :name, type: String, description: 'Name for this project'
 
     collection :labor
 

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -5,10 +5,11 @@ describe Magma::Attribute do
   describe "#json_template" do
     it "includes attribute defaults" do
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, {})
+      attribute = Magma::Attribute.new("name", model, { format_hint: "Hint" })
       template = attribute.json_template
 
       expect(template[:display_name]).to eq("Name")
+      expect(template[:format_hint]).to eq("Hint")
     end
 
     it "includes attributes saved in the database" do
@@ -18,14 +19,29 @@ describe Magma::Attribute do
         attribute_name: "name",
         created_at: Time.now,
         updated_at: Time.now,
-        display_name: "Something original"
+        display_name: "Something original",
+        format_hint: "A better hint!"
       )
 
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, {})
+      attribute = Magma::Attribute.new("name", model, { format_hint: "Hint" })
       template = attribute.json_template
 
       expect(template[:display_name]).to eq("Something original")
+      expect(template[:format_hint]).to eq("A better hint!")
+    end
+
+    it "includes updated attributes" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.
+        new("name", model, { match: "/^[a-z]/", desc: "Old name" })
+
+      attribute.update_option(:match, ".*")
+      attribute.update_option(:desc, "New name")
+      template = attribute.json_template
+
+      expect(template[:match]).to eq(".*")
+      expect(template[:desc]).to eq("New name")
     end
   end
 end

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -40,6 +40,14 @@ describe Magma::Attribute do
 
       expect(template[:desc]).to eq("New name")
     end
+
+    it "uses desc as a fallback for description" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, { desc: "Old name" })
+      template = attribute.json_template
+
+      expect(template[:desc]).to eq("Old name")
+    end
   end
 
   describe "#update_option" do

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -2,6 +2,47 @@ require_relative '../lib/magma'
 require 'yaml'
 
 describe Magma::Attribute do
+  describe "#initialize" do
+    it "sets options that only exist in the database" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        format_hint: "First M Last"
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+
+      expect(attribute.format_hint).to eq("First M Last")
+    end
+
+    it "sets options that only exist on the attribute" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, { format_hint: "Last, First M" })
+
+      expect(attribute.format_hint).to eq("Last, First M")
+    end
+
+    it "defers to options defined in the database when setting options" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        format_hint: "First M Last"
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, { format_hint: "Last, First M" })
+
+      expect(attribute.format_hint).to eq("First M Last")
+    end
+  end
+
   describe "#json_template" do
     it "includes attribute defaults" do
       model = double("model", project_name: :project, model_name: :model)

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -33,9 +33,9 @@ describe Magma::Attribute do
 
     it "includes updated attributes" do
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, { desc: "Old name" })
+      attribute = Magma::Attribute.new("name", model, { description: "Old name" })
 
-      attribute.update_option(:desc, "New name")
+      attribute.update_option(:description, "New name")
       template = attribute.json_template
 
       expect(template[:desc]).to eq("New name")
@@ -45,11 +45,11 @@ describe Magma::Attribute do
   describe "#update_option" do
     it "updates editable options" do
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, { desc: "Old name" })
+      attribute = Magma::Attribute.new("name", model, { description: "Old name" })
 
-      attribute.update_option(:desc, "New name")
+      attribute.update_option(:description, "New name")
 
-      expect(attribute.desc).to eq("New name")
+      expect(attribute.description).to eq("New name")
     end
 
     it "doesn't update non-editable options" do

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -33,15 +33,32 @@ describe Magma::Attribute do
 
     it "includes updated attributes" do
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.
-        new("name", model, { match: "/^[a-z]/", desc: "Old name" })
+      attribute = Magma::Attribute.new("name", model, { desc: "Old name" })
 
-      attribute.update_option(:match, ".*")
       attribute.update_option(:desc, "New name")
       template = attribute.json_template
 
-      expect(template[:match]).to eq(".*")
       expect(template[:desc]).to eq("New name")
+    end
+  end
+
+  describe "#update_option" do
+    it "updates editable options" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, { desc: "Old name" })
+
+      attribute.update_option(:desc, "New name")
+
+      expect(attribute.desc).to eq("New name")
+    end
+
+    it "doesn't update non-editable options" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, { match: "[A-z]" })
+
+      attribute.update_option(:match, ".*")
+
+      expect(attribute.match).to eq("[A-z]")
     end
   end
 end

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../lib/magma'
+require 'yaml'
+
+describe Magma::Attribute do
+  describe "#json_template" do
+    it "includes attribute defaults" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+      template = attribute.json_template
+
+      expect(template[:display_name]).to eq("Name")
+    end
+
+    it "includes attributes saved in the database" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        display_name: "Something original"
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+      template = attribute.json_template
+
+      expect(template[:display_name]).to eq("Something original")
+    end
+  end
+end

--- a/spec/magma_model_spec.rb
+++ b/spec/magma_model_spec.rb
@@ -16,15 +16,5 @@ describe Magma::Model do
       expect(template.values_at(:name, :identifier, :parent)).to eq([:monster, :name, :labor])
       expect(template[:attributes].keys).to include(:created_at, :updated_at, :labor, :name, :species)
     end
-
-    it "includes updated attributes" do
-      Labors::Monster.attributes[:species].update_option(:match, ".*")
-      Labors::Monster.attributes[:species].update_option(:desc, "Scary monsters!")
-
-      template = Labors::Monster.json_template
-
-      expect(template[:attributes][:species][:match]).to eq(".*")
-      expect(template[:attributes][:species][:desc]).to eq("Scary monsters!")
-    end
   end
 end

--- a/spec/magma_model_spec.rb
+++ b/spec/magma_model_spec.rb
@@ -16,5 +16,15 @@ describe Magma::Model do
       expect(template.values_at(:name, :identifier, :parent)).to eq([:monster, :name, :labor])
       expect(template[:attributes].keys).to include(:created_at, :updated_at, :labor, :name, :species)
     end
+
+    it "includes updated attributes" do
+      Labors::Monster.attributes[:species].update_option(:match, ".*")
+      Labors::Monster.attributes[:species].update_option(:desc, "Scary monsters!")
+
+      template = Labors::Monster.json_template
+
+      expect(template[:attributes][:species][:match]).to eq(".*")
+      expect(template[:attributes][:species][:desc]).to eq("Scary monsters!")
+    end
   end
 end


### PR DESCRIPTION
Per #99, this PR adds a global `attributes` table that stores attribute options `desc`, `display_name`, `match`, and `format_hint`. Options will be fetched from the `attributes` table for a project/model/attribute if it exists; otherwise, we'll continue to use the definition in the model file.

This PR also adds a `global_migrate` command to run database wide migrations. It could be merged into `migrate`, but handling the version flag could be weird. How would we tell if the requested version is for a global migration or a project specific migration?

This is our first pass through this problem -- we're happy for all feedback! 😄

/cc @notmarkmiranda 