### PR TITLE
Remove identifier type from spec models

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -22,14 +22,15 @@ class Magma
       set_options(opts)
     end
 
-    def _type
+    def database_type
+      nil
     end
 
     def json_template
       {
         name: @name,
         model_name: self.is_a?(Magma::Link) ? link_model.model_name : nil,
-        type: _type.nil? ? nil : _type.respond_to?(:name) ? _type.name : _type,
+        type: database_type.respond_to?(:name) ? database_type.name : database_type,
         attribute_class: self.class.name,
         desc: description,
         display_name: display_name,
@@ -53,11 +54,11 @@ class Magma
     def update(record, new_value)
       record.set({@name=> new_value})
 
-      if _type == DateTime
+      if database_type == DateTime
         return DateTime.parse(new_value)
-      elsif _type == Float
+      elsif database_type == Float
         return new_value.to_f
-      elsif _type == Integer
+      elsif database_type == Integer
         return new_value.to_i
       else
         return new_value

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -7,7 +7,7 @@ class Magma
 
     class << self
       def options
-        [:type, :description, :display_name, :hide, :readonly, :unique, :index, :match,
+        [:description, :display_name, :hide, :readonly, :unique, :index, :match,
 :format_hint, :loader, :link_model, :restricted, :desc ]
       end
 
@@ -23,14 +23,13 @@ class Magma
     end
 
     def _type
-      @type
     end
 
     def json_template
       {
         name: @name,
         model_name: self.is_a?(Magma::Link) ? link_model.model_name : nil,
-        type: @type.nil? ? nil : @type.respond_to?(:name) ? @type.name : @type,
+        type: _type.nil? ? nil : _type.respond_to?(:name) ? _type.name : _type,
         attribute_class: self.class.name,
         desc: description,
         display_name: display_name,
@@ -54,11 +53,11 @@ class Magma
     def update(record, new_value)
       record.set({@name=> new_value})
 
-      if @type == DateTime
+      if _type == DateTime
         return DateTime.parse(new_value)
-      elsif @type == Float
+      elsif _type == Float
         return new_value.to_f
-      elsif @type == Integer
+      elsif _type == Integer
         return new_value.to_i
       else
         return new_value

--- a/lib/magma/attributes/boolean_attribute.rb
+++ b/lib/magma/attributes/boolean_attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class BooleanAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: TrueClass))
+    def _type
+      TrueClass
     end
   end
 end

--- a/lib/magma/attributes/boolean_attribute.rb
+++ b/lib/magma/attributes/boolean_attribute.rb
@@ -1,6 +1,6 @@
 class Magma
   class BooleanAttribute < Attribute
-    def _type
+    def database_type
       TrueClass
     end
   end

--- a/lib/magma/attributes/date_time_attribute.rb
+++ b/lib/magma/attributes/date_time_attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class DateTimeAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: DateTime))
+    def _type
+      DateTime
     end
   end
 end

--- a/lib/magma/attributes/date_time_attribute.rb
+++ b/lib/magma/attributes/date_time_attribute.rb
@@ -1,6 +1,6 @@
 class Magma
   class DateTimeAttribute < Attribute
-    def _type
+    def database_type
       DateTime
     end
   end

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -6,7 +6,7 @@ class Magma
       super
     end
 
-    def _type
+    def database_type
       String
     end
 

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,10 +1,13 @@
 class Magma
   class FileAttribute < Attribute
     def initialize(name, model, opts)
-      @type = String
       file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
       Magma.instance.storage.setup_uploader(model, name, file_type) 
       super
+    end
+
+    def _type
+      String
     end
 
     def update(record, new_value)

--- a/lib/magma/attributes/float_attribute.rb
+++ b/lib/magma/attributes/float_attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class FloatAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: Float))
+    def _type
+      Float
     end
   end
 end

--- a/lib/magma/attributes/float_attribute.rb
+++ b/lib/magma/attributes/float_attribute.rb
@@ -1,6 +1,6 @@
 class Magma
   class FloatAttribute < Attribute
-    def _type
+    def database_type
       Float
     end
   end

--- a/lib/magma/attributes/integer_attribute.rb
+++ b/lib/magma/attributes/integer_attribute.rb
@@ -1,6 +1,6 @@
 class Magma
   class IntegerAttribute < Attribute
-    def _type
+    def database_type
       Integer
     end
   end

--- a/lib/magma/attributes/integer_attribute.rb
+++ b/lib/magma/attributes/integer_attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class IntegerAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: Integer))
+    def _type
+      Integer
     end
   end
 end

--- a/lib/magma/attributes/match.rb
+++ b/lib/magma/attributes/match.rb
@@ -1,6 +1,6 @@
 class Magma
   class MatchAttribute < Attribute
-    def _type
+    def database_type
       :json
     end
 

--- a/lib/magma/attributes/match.rb
+++ b/lib/magma/attributes/match.rb
@@ -1,8 +1,7 @@
 class Magma
   class MatchAttribute < Attribute
-    def initialize(name, model, opts)
-      opts.merge!(type: :json)
-      super
+    def _type
+      :json
     end
 
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation

--- a/lib/magma/attributes/matrix.rb
+++ b/lib/magma/attributes/matrix.rb
@@ -2,9 +2,8 @@ require 'set'
 
 class Magma
   class MatrixAttribute < Attribute
-    def initialize(name, model, opts)
-      opts.merge!(type: :json)
-      super
+    def _type
+      :json
     end
 
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation

--- a/lib/magma/attributes/matrix.rb
+++ b/lib/magma/attributes/matrix.rb
@@ -2,7 +2,7 @@ require 'set'
 
 class Magma
   class MatrixAttribute < Attribute
-    def _type
+    def database_type
       :json
     end
 

--- a/lib/magma/attributes/string_attribute.rb
+++ b/lib/magma/attributes/string_attribute.rb
@@ -1,7 +1,7 @@
 class Magma
   class StringAttribute < Attribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(type: String))
+    def _type
+      String
     end
   end
 end

--- a/lib/magma/attributes/string_attribute.rb
+++ b/lib/magma/attributes/string_attribute.rb
@@ -1,6 +1,6 @@
 class Magma
   class StringAttribute < Attribute
-    def _type
+    def database_type
       String
     end
   end

--- a/lib/magma/migration.rb
+++ b/lib/magma/migration.rb
@@ -50,7 +50,7 @@ class Magma
         ]
       when Magma::Attribute
         [
-          column_entry(att.column_name, att._type),
+          column_entry(att.column_name, att.database_type),
           att.unique && unique_entry(att.column_name),
           att.index && index_entry(att.column_name)
         ].compact
@@ -83,7 +83,7 @@ class Magma
       return true if att.is_a?(Magma::ForeignKeyAttribute)
 
       literal_type = att.is_a?(DateTimeAttribute)?  :"timestamp without time zone" :
-        Magma.instance.db.cast_type_literal(att._type)
+        Magma.instance.db.cast_type_literal(att.database_type)
 
       return model.schema[att.column_name][:db_type].to_sym == literal_type.to_sym
     end
@@ -181,7 +181,7 @@ class Magma
       @model.attributes.map do |name,att|
         next unless schema_supports_attribute?(@model,att)
         next if schema_unchanged?(@model,att)
-        column_type_entry(att.column_name, att._type)
+        column_type_entry(att.column_name, att.database_type)
       end.compact.flatten
     end
 

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -48,7 +48,7 @@ class Magma
       end
 
       # identifier attribute, sets a unique identifier
-      def identifier(name, opts)
+      def identifier(name, opts = {})
         string(name, opts.merge(unique: true))
         @identity = name
 

--- a/spec/labors/models/labor.rb
+++ b/spec/labors/models/labor.rb
@@ -2,7 +2,7 @@ module Labors
   class Labor < Magma::Model
     parent :project
 
-    identifier :name, type: String
+    identifier :name
 
     child :monster
 

--- a/spec/labors/models/monster.rb
+++ b/spec/labors/models/monster.rb
@@ -2,7 +2,7 @@ module Labors
   class Monster < Magma::Model
     parent :labor
 
-    identifier :name, type: String
+    identifier :name
     string :species, match: /^[a-z\s]+$/
     collection :victim
     table :aspect

--- a/spec/labors/models/project.rb
+++ b/spec/labors/models/project.rb
@@ -1,6 +1,6 @@
 module Labors
   class Project < Magma::Model
-    identifier :name, type: String, description: 'Name for this project'
+    identifier :name, description: 'Name for this project'
 
     collection :labor
 

--- a/spec/labors/models/victim.rb
+++ b/spec/labors/models/victim.rb
@@ -4,7 +4,7 @@ module Labors
 
     restricted
 
-    identifier :name, type: String
+    identifier :name
     string :country, restricted: true
   end
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -224,8 +224,8 @@ EOT
     end
 
     it 'changes column types' do
-      worth = Labors::Prize.attributes[:worth]
-      worth.instance_variable_set("@type",Float)
+      original_attribute = Labors::Prize.attributes.delete(:worth)
+      Labors::Prize.attributes[:worth] = Magma::Model.float(:worth)
 
       migration = Labors::Prize.migration
       expect(migration.to_s).to eq <<EOT.chomp
@@ -233,7 +233,7 @@ EOT
       set_column_type :worth, Float
     end
 EOT
-      worth.instance_variable_set("@type",Integer)
+      Labors::Prize.attributes[:worth] = original_attribute
     end
   end
 end


### PR DESCRIPTION
`Magma::Model#identifier` sets the type to string so there's no need to set it in the definitions.

https://github.com/mountetna/magma/blob/d6764d31e6e64b9447f6480e6af58cf14c3db0e1/lib/magma/model.rb#L50-L57
  
Also, update `Magma::Model#identifier` so `opts` defaults to an empty hash. Some spec models don't set any options.