### PR TITLE
Refactor identifier, parent, and link attributes

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -180,4 +180,7 @@ require_relative 'attributes/integer_attribute'
 require_relative 'attributes/boolean_attribute'
 require_relative 'attributes/date_time_attribute'
 require_relative 'attributes/float_attribute'
+require_relative 'attributes/identifier_attribute'
+require_relative 'attributes/parent_attribute'
+require_relative 'attributes/link_attribute'
 

--- a/lib/magma/attributes/identifier_attribute.rb
+++ b/lib/magma/attributes/identifier_attribute.rb
@@ -1,0 +1,9 @@
+class Magma
+  class IdentifierAttribute < StringAttribute
+    def initialize(name, model, opts)
+      super(name, model, opts.merge(unique: true))
+      model.identity = name
+      model.order(name) unless model.order
+    end
+  end
+end

--- a/lib/magma/attributes/link_attribute.rb
+++ b/lib/magma/attributes/link_attribute.rb
@@ -1,0 +1,9 @@
+class Magma
+  class LinkAttribute < ForeignKeyAttribute
+    def initialize(name, model, opts)
+      model.many_to_one(name, class: model.project_model(opts[:link_model] || name))
+      super(name, model, opts)
+    end
+  end
+end
+

--- a/lib/magma/attributes/parent_attribute.rb
+++ b/lib/magma/attributes/parent_attribute.rb
@@ -1,0 +1,10 @@
+class Magma
+  class ParentAttribute < ForeignKeyAttribute
+    def initialize(name=nil, model, opts)
+      unless name.nil?
+        model.many_to_one(name)
+        super(name, model, opts)
+      end
+    end
+  end
+end

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -6,12 +6,16 @@ class Magma
   Model = Class.new(Sequel::Model)
    
   class Model
+    ATTRIBUTES = [
+      :string, :integer, :boolean, :date_time, :float, :file, :image, 
+      :collection, :table, :match, :matrix, :child, :identifier, :parent, :link
+    ].freeze
     class << self
-      %i(string integer boolean date_time float file image collection table match matrix child foreign_key identifier parent link).each do |method_name|
+      ATTRIBUTES.each do |method_name|
         define_method method_name do |attribute_name=nil, opts={}|
           klass = "Magma::#{method_name.to_s.capitalize}_attribute".camelcase.constantize
-          attributes[attribute_name] = klass.new(attribute_name, self, opts)
           @parent = attribute_name if method_name == :parent
+          attributes[attribute_name] = klass.new(attribute_name, self, opts)
         end
       end
 
@@ -60,7 +64,7 @@ class Magma
         @identity
       end
 
-      def parent_model
+      def parent_model_name
         @parent
       end
 
@@ -86,7 +90,7 @@ class Magma
           ],
           identifier: identity,
           dictionary: @dictionary && @dictionary.to_hash,
-          parent: parent_model
+          parent: parent_model_name
         }.delete_if {|k,v| v.nil? }
       end
 

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -6,12 +6,12 @@ class Magma
   Model = Class.new(Sequel::Model)
    
   class Model
-    ATTRIBUTES = [
+    ATTRIBUTES_TYPES = [
       :string, :integer, :boolean, :date_time, :float, :file, :image, 
       :collection, :table, :match, :matrix, :child, :identifier, :parent, :link
     ].freeze
     class << self
-      ATTRIBUTES.each do |method_name|
+      ATTRIBUTES_TYPES.each do |method_name|
         define_method method_name do |attribute_name=nil, opts={}|
           klass = "Magma::#{method_name.to_s.capitalize}_attribute".camelcase.constantize
           @parent = attribute_name if method_name == :parent

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -7,10 +7,11 @@ class Magma
    
   class Model
     class << self
-      %i(string integer boolean date_time float file image collection table match matrix child foreign_key).each do |method_name|
-        define_method method_name do |attribute_name, opts={}|
+      %i(string integer boolean date_time float file image collection table match matrix child foreign_key identifier parent link).each do |method_name|
+        define_method method_name do |attribute_name=nil, opts={}|
           klass = "Magma::#{method_name.to_s.capitalize}_attribute".camelcase.constantize
           attributes[attribute_name] = klass.new(attribute_name, self, opts)
+          @parent = attribute_name if method_name == :parent
         end
       end
 
@@ -47,37 +48,20 @@ class Magma
         name.respond_to?(:to_sym) && @attributes.has_key?(name.to_sym)
       end
 
-      # identifier attribute, sets a unique identifier
-      def identifier(name, opts = {})
-        string(name, opts.merge(unique: true))
-        @identity = name
-
-        # Default ordering is by identifier.
-        order(name) unless @order
-      end
-
       def identity
         @identity || primary_key
+      end
+
+      def identity=(identity)
+        @identity = (identity)
       end
 
       def has_identifier?
         @identity
       end
 
-      # parent attribute, links to a parent record
-      def parent name=nil, opts = {}
-        if name
-          @parent = name
-          many_to_one name
-          foreign_key(name, opts)
-        end
+      def parent_model
         @parent
-      end
-
-      # link attribute, links to a single other record
-      def link(name, opts = {})
-        many_to_one(name, class: project_model(opts[:link_model] || name))
-        foreign_key(name, opts)
       end
 
       def restricted(opts= {})
@@ -102,7 +86,7 @@ class Magma
           ],
           identifier: identity,
           dictionary: @dictionary && @dictionary.to_hash,
-          parent: @parent
+          parent: parent_model
         }.delete_if {|k,v| v.nil? }
       end
 

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -23,7 +23,7 @@ class Magma
 
     def ordered_models(model)
       link_models = model.attributes.values.select do |att|
-        att.is_a?(Magma::Link) && att.link_model.parent == model.model_name
+        att.is_a?(Magma::Link) && att.link_model.parent_model == model.model_name
       end.map(&:link_model)
       link_models + link_models.map{|m| ordered_models(m)}.flatten
     end

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -23,7 +23,7 @@ class Magma
 
     def ordered_models(model)
       link_models = model.attributes.values.select do |att|
-        att.is_a?(Magma::Link) && att.link_model.parent_model == model.model_name
+        att.is_a?(Magma::Link) && att.link_model.parent_model_name == model.model_name
       end.map(&:link_model)
       link_models + link_models.map{|m| ordered_models(m)}.flatten
     end

--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -133,13 +133,13 @@ class Magma
       def initialize child, parent, parent_ids
         @child = child
         @parent = parent
-        raise unless @child.attributes[@child.parent_model].link_model == @parent
+        raise unless @child.attributes[@child.parent_model_name].link_model == @parent
         @parent_ids = parent_ids
       end
 
       def apply(attributes)
         [
-          [ @child.parent_model, '::identifier', '::in', @parent_ids ]
+          [ @child.parent_model_name, '::identifier', '::in', @parent_ids ]
         ]
       end
     end

--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -133,13 +133,13 @@ class Magma
       def initialize child, parent, parent_ids
         @child = child
         @parent = parent
-        raise unless @child.attributes[@child.parent].link_model == @parent
+        raise unless @child.attributes[@child.parent_model].link_model == @parent
         @parent_ids = parent_ids
       end
 
       def apply(attributes)
         [
-          [ @child.parent, '::identifier', '::in', @parent_ids ]
+          [ @child.parent_model, '::identifier', '::in', @parent_ids ]
         ]
       end
     end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -271,7 +271,7 @@ describe QueryController do
         [ 'labor', '::all', 'year' ]
       )
 
-      expect(json_body[:answer].map(&:last)).to eq(Labors::Labor.select_map(:year).map(&:iso8601))
+      expect(json_body[:answer].map(&:last)).to match_array(Labors::Labor.select_map(:year).map(&:iso8601))
       expect(json_body[:format]).to eq(['labors::labor#name', 'labors::labor#year'])
     end
   end

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -379,7 +379,7 @@ describe RetrieveController do
       expect(last_response.status).to eq(200)
 
       labor_names = json_body[:models][:labor][:documents].values.map{|d| d[:name]}
-      expect(labor_names).to match(new_labors.map(&:name))
+      expect(labor_names).to match_array(new_labors.map(&:name))
 
       Timecop.return
     end


### PR DESCRIPTION
#125 

This will refactor identifier, parent, and link to match the other attribute patterns. The only holdover was that the previous #parent method was a getter and setter method. There is an instance variable set in the define method group in order to set the parent on the model.