### PR TITLE
Use old attr class names in json_template

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -31,7 +31,7 @@ class Magma
         name: @name,
         model_name: self.is_a?(Magma::Link) ? link_model.model_name : nil,
         type: database_type.respond_to?(:name) ? database_type.name : database_type,
-        attribute_class: self.class.name,
+        attribute_class: attribute_class_name,
         desc: description,
         display_name: display_name,
         options: @match.is_a?(Array) ? @match : nil,
@@ -137,6 +137,31 @@ class Magma
       )
 
       persisted_attribute&.slice(*EDITABLE_OPTIONS) || {}
+    end
+
+    MAGMA_ATTRIBUTES = [
+      "Magma::BooleanAttribute",
+      "Magma::DateTimeAttribute",
+      "Magma::FloatAttribute",
+      "Magma::IdentifierAttribute",
+      "Magma::IntegerAttribute",
+      "Magma::StringAttribute"
+    ]
+
+    FOREIGN_KEY_ATTRIBUTES = [
+      "Magma::LinkAttribute",
+      "Magma::ParentAttribute"
+    ]
+
+    def attribute_class_name
+      case self.class.name
+      when *MAGMA_ATTRIBUTES
+        "Magma::Attribute"
+      when *FOREIGN_KEY_ATTRIBUTES
+        "Magma::ForeignKeyAttribute"
+      else
+        self.class.name
+      end
     end
 
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -89,6 +89,21 @@ describe Magma::Attribute do
 
       expect(template[:desc]).to eq("Old name")
     end
+
+    it "continues reporting attribute_class as 'Magma::Attribute' for old Magma::Attributes" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::BooleanAttribute.new("name", model, {})
+      template = attribute.json_template
+
+      expect(template[:attribute_class]).to eq("Magma::Attribute")
+    end
+
+    it "continues reporting attribute_class as 'Magma::ForeignKeyAttribute' for old Magma::ForeignKeyAttributes" do
+      attribute = Labors::Monster.attributes[:labor]
+      template = attribute.json_template
+
+      expect(template[:attribute_class]).to eq("Magma::ForeignKeyAttribute")
+    end
   end
 
   describe "#update_option" do


### PR DESCRIPTION
Since we've added new attribute classes, such as `Magma::BooleanAttribute` and `Magma::LinkAttribute`, `Magma::Attribute#json_template` has new values for `attribute_class`. This breaks the API for consumers like timur.

To keep the API consistent, we'll continue using the old attribute class names in `#json_template`. 

This should get timur back to a working state without needing any changes. Since I'm newer to timur, I could use another set of eyes to verify things work 😄