### PR TITLE
Issue51 copy file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem 'rspec'
   gem 'database_cleaner'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'timecop'
   gem 'net-http-persistent'
   gem 'multipart-post'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     database_cleaner (1.8.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.10)
+    etna (0.1.11)
       jwt
       multipart-post
       net-http-persistent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
+    byebug (11.1.3)
     carrierwave (2.0.2)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -31,7 +32,7 @@ GEM
     database_cleaner (1.8.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.8)
+    etna (0.1.10)
       jwt
       multipart-post
       net-http-persistent
@@ -84,8 +85,11 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (4.0.3)
-    rack (2.1.2)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.9.0)
@@ -139,6 +143,7 @@ DEPENDENCIES
   net-http-persistent
   pg
   pry
+  pry-byebug
   rack-test
   rspec
   sequel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     database_cleaner (1.8.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.11)
+    etna (0.1.12)
       jwt
       multipart-post
       net-http-persistent

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,9 +1,10 @@
+require 'pry'
 class Magma
   class FileAttribute < Attribute
     def initialize(name, model, opts)
       @type = String
       file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
-      Magma.instance.storage.setup_uploader(model, name, file_type) 
+      Magma.instance.storage.setup_uploader(model, name, file_type)
       super
     end
 
@@ -15,14 +16,18 @@ class Magma
           filename: '::blank'
         }]
       when '::temp'
-        return nil
+        return nil  # Here we should generate a temporary location?
       when %r!^metis://!
         return [ @name, {
           location: new_value,
           filename: filename(record_name, new_value)
         }]
       else
-        return nil
+        # return nil --> This didn't seem to save to the database?
+        return [ @name, {
+          location: nil,
+          filename: nil
+        }]
       end
     end
 

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,4 +1,3 @@
-require 'pry'
 class Magma
   class FileAttribute < Attribute
     def initialize(name, model, opts)

--- a/lib/magma/revision.rb
+++ b/lib/magma/revision.rb
@@ -7,6 +7,10 @@ class Magma
       @revision = revision
     end
 
+    def [](k)
+      @revision[k]
+    end
+
     def attribute_names
       @revision.keys
     end

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -166,5 +166,8 @@ class UpdateController < Magma::Controller
       hmac.url_params[:query]).map { |k,v| [k.to_sym, v] }.to_h
 
     client.send('post', hmac.url_params[:path], copy_params.merge(hmac_params))
+  rescue Etna::Error => e
+    log(e.message)
+    @errors.concat([e.message])
   end
 end

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -83,16 +83,15 @@ class UpdateController < Magma::Controller
     @revisions.each do |model, model_revisions|
       model_revisions.each do |revision|
 
-        revision.attribute_names.each do |attribute|
-          if is_file_attribute(revision.model, attribute)
-
-            if !revision.to_loader[attribute]  # nil
-              remove_copy_on_metis(revision, attribute)
-            elsif revision.to_loader[attribute][:location].start_with? 'metis:'
-              copy_file_on_metis(revision, attribute)
-            elsif revision.to_loader[attribute][:location] == '::blank'
-              remove_copy_on_metis(revision, attribute)
-            end
+        revision.attribute_names.select {
+          |attribute| is_file_attribute(revision.model, attribute)
+        }.each do |attribute|
+          if !revision[attribute]  # nil
+            remove_copy_on_metis(revision, attribute)
+          elsif revision[attribute].start_with? 'metis:'
+            copy_file_on_metis(revision, attribute)
+          elsif revision[attribute] == '::blank'
+            remove_copy_on_metis(revision, attribute)
           end
         end
       end
@@ -125,7 +124,9 @@ class UpdateController < Magma::Controller
     #   metis://<project>/<bucket>/<folder path>/<file name>
     # Splitting the above produces
     #   ["metis", "", "<project>", "<bucket>", "<folder path>" ... "file name"]
-    metis_file_location_parts = revision.to_loader[attribute][:location].split('/')
+    metis_file_location_parts = revision[attribute].split('/')
+
+    # We need the filename here, so we call to_loader
     new_file_name = revision.to_loader[attribute][:filename]
 
     # At some point, when Metis supports changing project names,

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -84,21 +84,21 @@ class UpdateController < Magma::Controller
       model_revisions.each do |revision|
 
         revision.attribute_names.select {
-          |attribute| is_file_attribute(revision.model, attribute)
-        }.each do |attribute|
-          if !revision[attribute]  # nil
-            remove_copy_on_metis(revision, attribute)
-          elsif revision[attribute].start_with? 'metis:'
-            copy_file_on_metis(revision, attribute)
-          elsif revision[attribute] == '::blank'
-            remove_copy_on_metis(revision, attribute)
+          |attribute_name| is_file_attribute(revision.model, attribute_name)
+        }.each do |attribute_name|
+          if !revision[attribute_name]  # nil
+            remove_copy_on_metis(revision, attribute_name)
+          elsif revision[attribute_name].start_with? 'metis:'
+            copy_file_on_metis(revision, attribute_name)
+          elsif revision[attribute_name] == '::blank'
+            remove_copy_on_metis(revision, attribute_name)
           end
         end
       end
     end
   end
 
-  def remove_copy_on_metis(revision, attribute)
+  def remove_copy_on_metis(revision, attribute_name)
     # First get the current value of the file attribute,
     #   so we can get the file extension.
     # When we need to construct the link filename
@@ -108,7 +108,7 @@ class UpdateController < Magma::Controller
     return
   end
 
-  def copy_file_on_metis(revision, attribute)
+  def copy_file_on_metis(revision, attribute_name)
     host = Magma.instance.config(:storage).fetch(:host)
 
     client = Etna::Client.new(
@@ -124,10 +124,10 @@ class UpdateController < Magma::Controller
     #   metis://<project>/<bucket>/<folder path>/<file name>
     # Splitting the above produces
     #   ["metis", "", "<project>", "<bucket>", "<folder path>" ... "file name"]
-    metis_file_location_parts = revision[attribute].split('/')
+    metis_file_location_parts = revision[attribute_name].split('/')
 
     # We need the filename here, so we call to_loader
-    new_file_name = revision.to_loader[attribute][:filename]
+    new_file_name = revision.to_loader[attribute_name][:filename]
 
     # At some point, when Metis supports changing project names,
     # this parameter should be the old file project name (metis_file_location_parts[2]))

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require_relative 'controller'
 
 class UpdateController < Magma::Controller

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -85,9 +85,7 @@ class UpdateController < Magma::Controller
           client = Etna::Client.new(
             "https://#{host}",
             @user.token)
-
-          copy_route = ''
-
+          binding.pry
           copy_route = client.routes.find { |r| r[:name] == 'copy' }
 
           next unless copy_route

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -162,18 +162,16 @@ class UpdateController < Magma::Controller
 
     hmac = Etna::Hmac.new(Magma.instance, hmac_params)
 
-    # For the params to show up on the other end in Metis,
-    #   need to include them in the request body. For POST
-    #   requests, the URL query params are ignored and
-    #   won't make it to the receiving route.
+    # These get re-encoded into query string by Etna Client
     hmac_params = Rack::Utils.parse_query(
       hmac.url_params[:query]).map { |k,v| [k.to_sym, v] }.to_h
 
     client.send(
-      'query_request',
+      'body_request_with_query_params',
       Net::HTTP::Post,
-      "#{hmac.url_params[:path]}?#{hmac.url_params[:query]}",
-      hmac_params)
+      hmac.url_params[:path],
+      hmac_params,
+      bulk_copy_params)
   rescue Etna::Error => e
     log(e.message)
     @errors.concat([e.message])

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -20,6 +20,11 @@ class UpdateController < Magma::Controller
 
     censor_revisions
 
+    # Unclear if this step to update file links in Metis should
+    # happen before load_revisions ... either could fail, which
+    # should cause the other to not run.
+    update_any_file_links if success?
+
     load_revisions if success?
 
     return success_json(@payload.to_hash) if success?
@@ -54,5 +59,81 @@ class UpdateController < Magma::Controller
   rescue Magma::LoadFailed => m
     log(m.complaints)
     @errors.concat(m.complaints)
+  end
+
+  def update_any_file_links
+    # Here, if there are any File attributes in the revisions,
+    #   we'll send a request to the Metis "copy" route, using the
+    #   Etna::Client.
+    # Assumes a conversion to Metis storage and no other
+    #   provider will be set.
+
+    # Etna::Client.new throws an exception if the host config includes protocol,
+    # i.e. https://metis-dev.etna-development.org will throw an exception
+    # raise Etna::BadRequest, 'Storage host should not include protocol' if
+    #   Magma.instance.config(:storage).fetch(:host).start_with? 'http'
+
+    auth = Etna::Auth.new(:magma)
+
+    host = Magma.instance.config(:storage).fetch(:host)
+
+    client = Etna::Client.new(
+      "https://#{host}",
+      @request.cookies[Magma.instance.config(:token_name)] || auth.send('auth', *[@request, :magma]))
+
+    copy_route = ''
+
+    client.routes.each do |route|
+      if route[:name] == 'copy'
+        copy_route = route
+        break
+      end
+    end
+
+    if copy_route == ''
+      return
+    end
+
+    @revisions.each do |model, model_revisions|
+      model_revisions.each do |revision|
+
+        # The below test for :stats as a File indicator seems
+        #   brittle -- anything better?
+        if revision.to_loader.key?(:stats)
+          path = client.send('route_path', *[copy_route, {:project_name => "foo", :bucket_name => "magma", :file_path => "test.txt"}])
+
+          hmac_signature = auth.send('etna_param', *[@request, :signature])
+
+          return false unless hmac_signature
+
+          return false unless headers = auth.send('etna_param', *[@request, :headers])
+
+          headers = headers.split(/,/).map do |header|
+            [ header.to_sym, auth.send('etna_param', *[@request, header]) ]
+          end.to_h
+
+          # Now expect the standard headers
+          hmac_params = {
+            method: 'post',
+            host: host,
+            path: path,
+
+            expiration: auth.send('etna_param', *[@request, :expiration]),
+            id: auth.send('etna_param', *[@request, :id]),
+            nonce: auth.send('etna_param', *[@request, :nonce]),
+            headers: headers,
+            test_signature: hmac_signature
+          }
+
+          hmac = Etna::Hmac.new(application, hmac_params)
+
+          # request.env['etna.hmac'] = hmac
+
+          return nil unless hmac.valid?
+
+          client.post(hmac.url_params[:path], hmac.url_params[:query])
+        end
+      end
+    end
   end
 end

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require_relative 'controller'
 
 class UpdateController < Magma::Controller

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -145,7 +145,7 @@ class UpdateController < Magma::Controller
       project_name: @project_name)
 
     bulk_copy_params = {
-      revisions: revisions
+      revisions: JSON.generate(revisions)
     }
 
     # Now populate the standard headers
@@ -167,11 +167,10 @@ class UpdateController < Magma::Controller
       hmac.url_params[:query]).map { |k,v| [k.to_sym, v] }.to_h
 
     client.send(
-      'body_request_with_query_params',
+      'query_request',
       Net::HTTP::Post,
       hmac.url_params[:path],
-      hmac_params,
-      bulk_copy_params)
+      hmac_params.merge(bulk_copy_params))
   rescue Etna::Error => e
     log(e.message)
     @errors.concat([e.message])

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -120,7 +120,9 @@ class UpdateController < Magma::Controller
       end
     end
 
-    execute_bulk_copy_on_metis(copy_revisions)
+    if copy_revisions.length > 0
+      execute_bulk_copy_on_metis(copy_revisions)
+    end
   end
 
   def execute_bulk_copy_on_metis(revisions)

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -145,7 +145,7 @@ class UpdateController < Magma::Controller
       project_name: @project_name)
 
     bulk_copy_params = {
-      revisions: JSON.generate(revisions)
+      revisions: revisions
     }
 
     # Now populate the standard headers
@@ -162,15 +162,11 @@ class UpdateController < Magma::Controller
 
     hmac = Etna::Hmac.new(Magma.instance, hmac_params)
 
-    # These get re-encoded into query string by Etna Client
-    hmac_params = Rack::Utils.parse_query(
-      hmac.url_params[:query]).map { |k,v| [k.to_sym, v] }.to_h
-
     client.send(
-      'query_request',
+      'body_request',
       Net::HTTP::Post,
-      hmac.url_params[:path],
-      hmac_params.merge(bulk_copy_params))
+      hmac.url_params[:path] + '?' + hmac.url_params[:query],
+      bulk_copy_params)
   rescue Etna::Error => e
     log(e.message)
     @errors.concat([e.message])

--- a/lib/magma/server/update.rb
+++ b/lib/magma/server/update.rb
@@ -169,6 +169,7 @@ class UpdateController < Magma::Controller
       bulk_copy_params)
   rescue Etna::Error => e
     log(e.message)
-    @errors.concat([e.message])
+    # We receive a stringified JSON error from Metis
+    @errors.push(JSON.parse(e.message))
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -11,6 +11,13 @@ describe Magma::Client do
     stub_request(:post, 'https://magma.test/retrieve').to_rack(app)
     stub_request(:post, 'https://magma.test/query').to_rack(app)
     stub_request(:post, 'https://magma.test/update').to_rack(app)
+
+    route_payload = JSON.generate([
+      {:success=>true}
+    ])
+    stub_request(:any, /https:\/\/metis.test/).
+      to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
+
     @token = Base64.strict_encode64(AUTH_USERS[:editor].to_json)
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -5,6 +5,14 @@ describe QueryController do
     OUTER_APP
   end
 
+  before(:each) do
+    route_payload = JSON.generate([
+      {:success=>true}
+    ])
+    stub_request(:any, /https:\/\/metis.test/).
+      to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
+  end
+
   def query(question,user_type=:viewer)
     auth_header(user_type)
     json_post(:query, {project_name: 'labors', query: question})

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -137,8 +137,8 @@ describe RetrieveController do
       json = json_body
 
       # any model with an identifier returns all records
-      expect(json[:models][:labor][:documents].keys).to match(labors.map(&:name).map(&:to_sym))
-      expect(json[:models][:monster][:documents].keys).to match(monsters.map(&:name).map(&:to_sym))
+      expect(json[:models][:labor][:documents].keys).to match_array(labors.map(&:name).map(&:to_sym))
+      expect(json[:models][:monster][:documents].keys).to match_array(monsters.map(&:name).map(&:to_sym))
 
       # it does not return a model with no identifier
       expect(json[:models][:prize]).to be_nil
@@ -168,7 +168,7 @@ describe RetrieveController do
         project_name: 'labors',
         model_name: 'prize',
         record_names: prizes[0..1].map(&:id),
-        attribute_names: 'all' 
+        attribute_names: 'all'
       )
 
       expect(json_body[:models][:prize][:documents].keys).to eq(prizes[0..1].map(&:id).map(&:to_s).map(&:to_sym))

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -16,7 +16,6 @@ describe 'Magma::Storage' do
 
             # While we won't validate the HMAC results, let's make sure
             #   the right params are included
-            expect(download_url.include? 'X-Etna-Authorization').to be true
             expect(download_url.include? 'X-Etna-Expiration').to be true
             expect(download_url.include? 'X-Etna-Nonce').to be true
             expect(download_url.include? 'X-Etna-Id').to be true
@@ -37,7 +36,6 @@ describe 'Magma::Storage' do
 
             # While we won't validate the HMAC results, let's make sure
             #   the right params are included
-            expect(upload_url.include? 'X-Etna-Authorization').to be true
             expect(upload_url.include? 'X-Etna-Expiration').to be true
             expect(upload_url.include? 'X-Etna-Nonce').to be true
             expect(upload_url.include? 'X-Etna-Id').to be true

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,0 +1,51 @@
+require 'pry'
+
+describe 'Magma::Storage' do
+    include Rack::Test::Methods
+
+    def app
+      OUTER_APP
+    end
+
+    it 'returns a download URL.' do
+        # The test config is usually Metis storage, but
+        #   let's make this conditional just in case not.
+        if Magma.instance.config(:storage).fetch(:provider).downcase == 'metis'
+            download_url = Magma.instance.storage.download_url('foo', 'root/path/to/file').to_s
+            expect(download_url.include? 'foo/download/magma/root/path/to/file').to be true
+
+            # While we won't validate the HMAC results, let's make sure
+            #   the right params are included
+            expect(download_url.include? 'X-Etna-Authorization').to be true
+            expect(download_url.include? 'X-Etna-Expiration').to be true
+            expect(download_url.include? 'X-Etna-Nonce').to be true
+            expect(download_url.include? 'X-Etna-Id').to be true
+            expect(download_url.include? 'X-Etna-Headers').to be true
+
+            # Just to make sure we're sane
+            expect(download_url.include? 'upload/magma').to be false
+            expect(download_url.include? 'file/copy/magma').to be false
+        end
+    end
+
+    it 'returns an upload URL.' do
+        # The test config is usually Metis storage, but
+        #   let's make this conditional just in case not.
+        if Magma.instance.config(:storage).fetch(:provider).downcase == 'metis'
+            upload_url = Magma.instance.storage.upload_url('foo', 'root/path/to/file').to_s
+            expect(upload_url.include? 'foo/upload/magma/root/path/to/file').to be true
+
+            # While we won't validate the HMAC results, let's make sure
+            #   the right params are included
+            expect(upload_url.include? 'X-Etna-Authorization').to be true
+            expect(upload_url.include? 'X-Etna-Expiration').to be true
+            expect(upload_url.include? 'X-Etna-Nonce').to be true
+            expect(upload_url.include? 'X-Etna-Id').to be true
+            expect(upload_url.include? 'X-Etna-Headers').to be true
+
+            # Just to make sure we're sane
+            expect(upload_url.include? 'download/magma').to be false
+            expect(upload_url.include? 'file/copy/magma').to be false
+        end
+    end
+  end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -13,6 +13,12 @@ describe UpdateController do
     ])
     stub_request(:options, 'https://metis.test').
     to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
+
+    route_payload = JSON.generate([
+      {:success=>true}
+    ])
+    stub_request(:post, "https://metis.test/labors/file/copy/magma/test.txt").
+    to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
   end
 
   def update(revisions, user_type=:editor)
@@ -210,6 +216,10 @@ describe UpdateController do
       expect(uri.path).to eq('/labors/download/magma/monster-Nemean%20Lion-stats.txt')
       expect(params['X-Etna-Id']).to eq('magma')
       expect(params['X-Etna-Expiration']).to eq((Time.now + Magma.instance.config(:storage)[:download_expiration]).iso8601)
+
+      # Make sure the Metis copy endpoint was called
+      assert_requested(:post, "https://metis.test/labors/file/copy/magma/test.txt",
+        times: 1)
 
       Timecop.return
     end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -159,7 +159,7 @@ describe UpdateController do
 
       # May be overkill ... but making sure each of the anticipated
       #   exceptions from Metis copy results in a failed Magma update.
-      bad_request_statuses = [400, 404, 403, 500]
+      bad_request_statuses = [400, 403, 404, 422, 500]
       req_counter = 0
       bad_request_statuses.each do |status|
         stub_request(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt").
@@ -175,7 +175,7 @@ describe UpdateController do
         req_counter += 1
         lion.refresh
         expect(lion.stats).to eq nil  # Did not change from the create state
-        expect(last_response.status).to eq(status)
+        expect(last_response.status).to eq(422)
 
         # Make sure the Metis copy endpoint was called
         assert_requested(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt",

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -10,7 +10,7 @@ describe UpdateController do
 
   before(:each) do
     route_payload = JSON.generate([
-      {:method=>"POST", :route=>"/:project_name/file/bulk_copy", :name=>"file_bulk_copy", :params=>["project_name"]}
+      {:method=>"POST", :route=>"/:project_name/files/copy", :name=>"file_bulk_copy", :params=>["project_name"]}
     ])
     stub_request(:options, 'https://metis.test').
     to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
@@ -18,7 +18,7 @@ describe UpdateController do
     route_payload = JSON.generate([
       {:success=>true}
     ])
-    stub_request(:post, /https:\/\/metis.test\/labors\/file\/bulk_copy?/).
+    stub_request(:post, /https:\/\/metis.test\/labors\/files\/copy?/).
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
   end
 
@@ -149,7 +149,7 @@ describe UpdateController do
     expect(json_document(:codex, entry.id.to_s)).to eq(lore: new_lore.symbolize_keys)
 
     # Make sure the Metis copy endpoint was not called
-    expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+    expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/files/copy").
     with(query: hash_including({
       "X-Etna-Headers": "revisions"
     }))
@@ -164,7 +164,7 @@ describe UpdateController do
       bad_request_statuses = [400, 403, 404, 422, 500]
       req_counter = 0
       bad_request_statuses.each do |status|
-        stub_request(:post, /https:\/\/metis.test\/labors\/file\/bulk_copy?/).
+        stub_request(:post, /https:\/\/metis.test\/labors\/files\/copy?/).
           to_return(status: status)
 
         update(
@@ -205,7 +205,7 @@ describe UpdateController do
       expect(json_document(:monster, 'Nemean Lion')[:stats][:url]).to be_nil
 
       # Make sure the Metis copy endpoint was not called
-      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/files/copy").
       with(query: hash_including({
         "X-Etna-Headers": "revisions"
       }))
@@ -232,7 +232,7 @@ describe UpdateController do
       expect(json_document(:monster, 'Nemean Lion')[:stats]).to be_nil
 
       # Make sure the Metis copy endpoint was not called
-      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/files/copy").
       with(query: hash_including({
         "X-Etna-Headers": "revisions"
       }))
@@ -261,7 +261,7 @@ describe UpdateController do
       })
 
       # Make sure the Metis copy endpoint was not called
-      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/files/copy").
       with(query: hash_including({
         "X-Etna-Headers": "revisions"
       }))
@@ -292,7 +292,7 @@ describe UpdateController do
       expect(params['X-Etna-Expiration']).to eq((Time.now + Magma.instance.config(:storage)[:download_expiration]).iso8601)
 
       # Make sure the Metis copy endpoint was called
-      expect(WebMock).to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      expect(WebMock).to have_requested(:post, "https://metis.test/labors/files/copy").
         with(query: hash_including({
           "X-Etna-Headers": "revisions"
         }))

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -146,6 +146,10 @@ describe UpdateController do
 
     expect(last_response.status).to eq(200)
     expect(json_document(:codex, entry.id.to_s)).to eq(lore: new_lore.symbolize_keys)
+
+    # Make sure the Metis copy endpoint was not  called
+    assert_not_requested(:post, "https://metis.test/labors/file/copy/magma/test.txt")
+
   end
 
   context 'file attributes' do

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -165,7 +165,7 @@ describe UpdateController do
       req_counter = 0
       bad_request_statuses.each do |status|
         stub_request(:post, /https:\/\/metis.test\/labors\/files\/copy?/).
-          to_return(status: status)
+          to_return(status: status, body: '{}')
 
         update(
           monster: {

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -149,8 +149,10 @@ describe UpdateController do
     expect(json_document(:codex, entry.id.to_s)).to eq(lore: new_lore.symbolize_keys)
 
     # Make sure the Metis copy endpoint was not called
-    assert_not_requested(:post, "/metis.test\/labors\/file\/copy/")
-
+    expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+    with(query: hash_including({
+      "X-Etna-Headers": "revisions"
+    }))
   end
 
   context 'file attributes' do
@@ -203,7 +205,10 @@ describe UpdateController do
       expect(json_document(:monster, 'Nemean Lion')[:stats][:url]).to be_nil
 
       # Make sure the Metis copy endpoint was not called
-      assert_not_requested(:post, "/metis.test\/labors\/file\/copy/")
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      with(query: hash_including({
+        "X-Etna-Headers": "revisions"
+      }))
     end
 
     it 'removes a file reference' do
@@ -227,7 +232,10 @@ describe UpdateController do
       expect(json_document(:monster, 'Nemean Lion')[:stats]).to be_nil
 
       # Make sure the Metis copy endpoint was not called
-      assert_not_requested(:post, "/metis.test\/labors\/file\/bulk_copy/")
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      with(query: hash_including({
+        "X-Etna-Headers": "revisions"
+      }))
     end
 
     it 'removes a file reference using ::blank' do
@@ -253,7 +261,10 @@ describe UpdateController do
       })
 
       # Make sure the Metis copy endpoint was not called
-      assert_not_requested(:post, "/metis.test\/labors\/file\/bulk_copy/")
+      expect(WebMock).not_to have_requested(:post, "https://metis.test/labors/file/bulk_copy").
+      with(query: hash_including({
+        "X-Etna-Headers": "revisions"
+      }))
     end
 
     it 'links a file from metis' do

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -228,7 +228,10 @@ describe UpdateController do
 
       # Make sure the Metis copy endpoint was called
       assert_requested(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt",
-        times: 1)
+        times: 1) { |req| req.body == JSON.generate({
+          'new_bucket_name': 'magma',
+          'new_file_path': 'monster-Nemean Lion-stats.txt'
+        })}
 
       Timecop.return
     end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'json'
 
 describe UpdateController do
@@ -17,7 +18,7 @@ describe UpdateController do
     route_payload = JSON.generate([
       {:success=>true}
     ])
-    stub_request(:post, "https://metis.test/labors/file/copy/magma/test.txt").
+    stub_request(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt").
     to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
   end
 
@@ -147,8 +148,8 @@ describe UpdateController do
     expect(last_response.status).to eq(200)
     expect(json_document(:codex, entry.id.to_s)).to eq(lore: new_lore.symbolize_keys)
 
-    # Make sure the Metis copy endpoint was not  called
-    assert_not_requested(:post, "https://metis.test/labors/file/copy/magma/test.txt")
+    # Make sure the Metis copy endpoint was not called
+    assert_not_requested(:post, "/metis.test\/labors\/file\/copy/")
 
   end
 
@@ -197,9 +198,9 @@ describe UpdateController do
     end
 
     it 'links a file from metis' do
+      binding.pry
       Timecop.freeze(DateTime.new(500))
       lion = create(:monster, name: 'Nemean Lion', species: 'lion')
-
       update(
         monster: {
           'Nemean Lion' => {
@@ -222,7 +223,7 @@ describe UpdateController do
       expect(params['X-Etna-Expiration']).to eq((Time.now + Magma.instance.config(:storage)[:download_expiration]).iso8601)
 
       # Make sure the Metis copy endpoint was called
-      assert_requested(:post, "https://metis.test/labors/file/copy/magma/test.txt",
+      assert_requested(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt",
         times: 1)
 
       Timecop.return

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -1,8 +1,18 @@
+require 'json'
+
 describe UpdateController do
   include Rack::Test::Methods
 
   def app
     OUTER_APP
+  end
+
+  before(:each) do
+    route_payload = JSON.generate([
+      {:method=>"POST", :route=>"/:project_name/file/copy/:bucket_name/:file_path", :name=>"copy", :params=>["project_name", "bucket_name", "file_path"]}
+    ])
+    stub_request(:options, 'https://metis.test').
+    to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
   end
 
   def update(revisions, user_type=:editor)

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -228,10 +228,11 @@ describe UpdateController do
 
       # Make sure the Metis copy endpoint was called
       assert_requested(:post, "https://metis.test/labors/file/copy/files/lion-stats.txt",
-        times: 1) { |req| req.body == JSON.generate({
-          'new_bucket_name': 'magma',
-          'new_file_path': 'monster-Nemean Lion-stats.txt'
-        })}
+        times: 1) do |req|
+          (req.body.include? 'new_bucket_name') &&
+          (req.body.include? 'new_file_path') &&
+          (req.body.include? 'X-Etna-Signature')
+        end
 
       Timecop.return
     end

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -9,7 +9,7 @@ describe UpdateController do
 
   before(:each) do
     route_payload = JSON.generate([
-      {:method=>"POST", :route=>"/:project_name/file/copy/:bucket_name/:file_path", :name=>"copy", :params=>["project_name", "bucket_name", "file_path"]}
+      {:method=>"POST", :route=>"/:project_name/file/copy/:bucket_name/:file_path", :name=>"file_copy", :params=>["project_name", "bucket_name", "file_path"]}
     ])
     stub_request(:options, 'https://metis.test').
     to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})

--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'json'
 
 describe UpdateController do
@@ -174,6 +173,9 @@ describe UpdateController do
       # but we do get an upload url for Metis
       expect(json_document(:monster, 'Nemean Lion')[:stats][:path]).to eq('::blank')
       expect(json_document(:monster, 'Nemean Lion')[:stats][:url]).to be_nil
+
+      # Make sure the Metis copy endpoint was not called
+      assert_not_requested(:post, "/metis.test\/labors\/file\/copy/")
     end
 
     it 'removes a file reference' do
@@ -195,10 +197,12 @@ describe UpdateController do
 
       # but we do get an upload url for Metis
       expect(json_document(:monster, 'Nemean Lion')[:stats]).to be_nil
+
+      # Make sure the Metis copy endpoint was not called
+      assert_not_requested(:post, "/metis.test\/labors\/file\/copy/")
     end
 
     it 'links a file from metis' do
-      binding.pry
       Timecop.freeze(DateTime.new(500))
       lion = create(:monster, name: 'Nemean Lion', species: 'lion')
       update(


### PR DESCRIPTION
@graft , can you give this another look? One thing I wasn't sure about in the [test stubs](https://github.com/mountetna/magma/compare/40-use-loader-for-update...issue51-take2-use-metis-storage?expand=1#diff-f999d89edde83b171d0e86e801229cdcR12) was the exact format of the returned "routes" that get fed into `Etna::Client`. The definitions in Metis show:

```
/:project_name/file/copy/:bucket_name/*file_path
```

But I don't think the route parser handles `*file_path` correctly, and I'm not exactly sure how it gets populated "in real life" in Etna (i.e. `*file_path` or `:file_path`). Is there a way I can investigate that locally? I've tried going into a Magma console (`bin/magma console`), but can't stand up an Etna::Client because it can't verify SSL certs.

