### PR TITLE
Add attr validation options to attributes table

### DIFF
--- a/db/migrations/002_add_validation_to_attributes.rb
+++ b/db/migrations/002_add_validation_to_attributes.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:attributes) do
+      add_column :validation, :json
+    end
+  end
+end

--- a/lib/magma/validation_object.rb
+++ b/lib/magma/validation_object.rb
@@ -74,7 +74,7 @@ class Magma
 
   class RegexpValidationObject < ValidationObject
     def validate(value)
-      @object.match(value)
+      @object.match?(value)
     end
 
     def error_message(name, value, hint)

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -127,7 +127,7 @@ describe Magma::Attribute do
   end
 
   describe "#update_option" do
-    it "updates editable options" do
+    it "updates editable string backed options" do
       model = double("model", project_name: :project, model_name: :model)
       attribute = Magma::Attribute.new("name", model, { description: "Old name" })
 
@@ -136,13 +136,57 @@ describe Magma::Attribute do
       expect(attribute.description).to eq("New name")
     end
 
+    it "updates editable JSON backed options" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {
+        validation: { type: "Array", value: [1, 2, 3] }
+      })
+
+      # Call attribute#validation_object to verify the cached validation_object
+      # gets reset
+      attribute.validation_object
+
+      attribute.update_option(:validation, { type: "Array", value: [4, 5, 6] })
+
+      expect(attribute.validation_object.options).to eq([4, 5, 6])
+    end
+
     it "doesn't update non-editable options" do
       model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, { validation: "[A-z]" })
+      attribute = Magma::Attribute.new("name", model, { restricted: true })
 
-      attribute.update_option(:validation, ".*")
+      attribute.update_option(:restricted, false)
 
-      expect(attribute.validation).to eq("[A-z]")
+      expect(attribute.restricted).to eq(true)
+    end
+  end
+
+  describe "#validation_object" do
+    it "builds validation objects using validation options from the database" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        validation: Sequel.pg_json_wrap(
+          { type: "Regexp", value: "^[a-zA-Z]{1}$" }
+        )
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+
+      expect(attribute.validation_object.match).to eq("^[a-zA-Z]{1}$")
+    end
+
+    it "builds validation objects using validation options defined on the attribute" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {
+        validation: { type: "Regexp", value: /^[a-zA-Z]{1}$/ }
+      })
+
+      expect(attribute.validation_object.match).to eq("^[a-zA-Z]{1}$")
     end
   end
 end

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -162,7 +162,61 @@ describe Magma::Attribute do
   end
 
   describe "#validation_object" do
-    it "builds validation objects using validation options from the database" do
+    it "builds ArrayValidationObjects using validation options from the database" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        validation: Sequel.pg_json_wrap(
+          { type: "Array", value: ["a", "b", "c"] }
+        )
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+
+      expect(attribute.validation_object.validate("a")).to eq(true)
+    end
+
+    it "builds ArrayValidationObjects using validation options defined on the attribute" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {
+        validation: { type: "Array", value: ["a", "b", "c"] }
+      })
+
+      expect(attribute.validation_object.validate("a")).to eq(true)
+    end
+
+    it "builds RangeValidationObjects using validation options from the database" do
+      Magma.instance.db[:attributes].insert(
+        project_name: "project",
+        model_name: "model",
+        attribute_name: "name",
+        created_at: Time.now,
+        updated_at: Time.now,
+        validation: Sequel.pg_json_wrap(
+          { type: "Range", begin: 1, end: 10 }
+        )
+      )
+
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {})
+
+      expect(attribute.validation_object.validate(5)).to eq(true)
+    end
+
+    it "builds RangeValidationObjects using validation options defined on the attribute" do
+      model = double("model", project_name: :project, model_name: :model)
+      attribute = Magma::Attribute.new("name", model, {
+        validation: { type: "Range", begin: 1, end: 10 }
+      })
+
+      expect(attribute.validation_object.validate(5)).to eq(true)
+    end
+
+    it "builds RegexpValidationObjects using validation options from the database" do
       Magma.instance.db[:attributes].insert(
         project_name: "project",
         model_name: "model",
@@ -177,16 +231,16 @@ describe Magma::Attribute do
       model = double("model", project_name: :project, model_name: :model)
       attribute = Magma::Attribute.new("name", model, {})
 
-      expect(attribute.validation_object.match).to eq("^[a-zA-Z]{1}$")
+      expect(attribute.validation_object.validate("A")).to eq(true)
     end
 
-    it "builds validation objects using validation options defined on the attribute" do
+    it "builds RegexpValidationObjects using validation options defined on the attribute" do
       model = double("model", project_name: :project, model_name: :model)
       attribute = Magma::Attribute.new("name", model, {
         validation: { type: "Regexp", value: /^[a-zA-Z]{1}$/ }
       })
 
-      expect(attribute.validation_object.match).to eq("^[a-zA-Z]{1}$")
+      expect(attribute.validation_object.validate("A")).to eq(true)
     end
   end
 end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -28,7 +28,7 @@ describe Magma::Validation do
     end
   end
 
-  context 'string attribute validations' do
+  context 'attribute validations' do
     after(:each) do
       remove_validation_stubs
     end
@@ -148,12 +148,6 @@ describe Magma::Validation do
         }
       )
       expect(errors).to be_empty
-    end
-  end
-
-  context 'attribute range validations' do
-    after(:each) do
-      remove_validation_stubs
     end
 
     it 'validates a range' do


### PR DESCRIPTION
This PR follows up on https://github.com/mountetna/magma/pull/135 by adding attribute validation options to the attributes table. Like the other `Magma::Attribute::EDITABLE_OPTIONS`, validation options stored in the attributes table will be loaded in favor of any defined on models in Ruby.

## Dealing with cached validation objects

There is a little weirdness around updating validation options that are already loaded in memory. When we convert validations to validation objects, we cache the validation object.

https://github.com/mountetna/magma/blob/453cf160ffc7207a4ac7e25d2bb027ebc683e179/lib/magma/attribute.rb#L29-L31

So if a validation that was already loaded in memory is changed in the attributes table, the validation object will still be based on the old validation data.

```ruby
irb(main):002:0> Ipi::Patient.attributes[:sop_version].validation_object
=> #<Magma::ArrayValidationObject:0x000055a9ec68c248 @object=["SOP1", "SOP2", "SOP3"]>
irb(main):008:0> Magma.instance.db[:attributes].insert(project_name: "ipi", model_name: "patient", attribute_name: "sop_version", validation: Sequel.pg_json_wrap({ type: "Array", value: ["SOP4", "SOP5"] }))
=> nil
irb(main):009:0> Ipi::Patient.attributes[:sop_version].validation_object
=> #<Magma::ArrayValidationObject:0x000055a9ec68c248 @object=["SOP1", "SOP2", "SOP3"]>
```

[`Magma::Attribute#update_option`](https://github.com/mountetna/magma/blob/88ddc3d4ba626edeb508d651afbe9c7387349c73/lib/magma/attribute.rb#L124) has been updated to reset the cached validation object so this might no be a huge issue. However, if we update validations some other way we'll have to watch out for this. Alternatively, we could stop caching the validation object but I'm not sure if that's a better approach.

## Migration version conflicts

This PR adds a migration, `db/migrations/002_add_validation_to_attributes.rb`, and https://github.com/mountetna/magma/pull/134 adds a migration, `db/migrations/002_add_link_model_to_attribute.rb`. After whichever PR gets merged, the other will have to change its migration version to 003. /cc @notmarkmiranda 

See https://github.com/mountetna/magma/issues/126.