### PR TITLE
Skip update file spec

### DIFF
--- a/spec/update_spec.rb
+++ b/spec/update_spec.rb
@@ -129,7 +129,7 @@ describe UpdateController do
     expect(json_document(:codex, entry.id.to_s)).to eq(lore: new_lore.symbolize_keys)
   end
 
-  it 'updates a file attribute' do
+  xit 'updates a file attribute' do
     Timecop.freeze(DateTime.new(500))
     lion = create(:monster, name: 'Nemean Lion', species: 'lion')
 


### PR DESCRIPTION
This will temporarily skip the update file spec until we have a chance to fix it.