### PR TITLE
Hotfix for link_model in project.rb

### DIFF
--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -38,7 +38,7 @@ class Magma
     def ordered_models(model)
       link_models = model.attributes.values.select do |att|
         att.is_a?(Magma::Link) && att.link_model.parent_model_name == model.model_name
-      end.map(&:link_model_name)
+      end.map(&:link_model)
       link_models + link_models.map{|m| ordered_models(m)}.flatten
     end
 


### PR DESCRIPTION
I must have not saved before committing / pushing on #144.

This will fix the trailing .map on #ordered_models.