### PR TITLE
Use GitHub Actions to run test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,22 +15,34 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    env:
+      MAGMA_ENV: test
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Set up Ruby 2.5
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.5
-    - name: Setup deps and run RSpec test suite
+    - name: Bundle install
+      run: |
+        gem install bundler -v 2.1.4
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - name: Set up database
       env:
         PGHOST: 127.0.0.1
         PGUSER: developer
-        MAGMA_ENV: test
       run: |
-        gem install bundler -v 2.1.4
-        bundle install --jobs 4 --retry 3
         cp config.yml.test config.yml
         bin/magma create_db labors
         bin/magma migrate
         bin/magma global_migrate
+    - name: Run RSpec test suite
+      run: |
         rspec spec/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,6 @@ jobs:
       run: |
         bundle exec rspec spec/
     - name: Run test suite again to detect flaky failures
-      if: ${{ steps.first_test_run.outcome == "success" }}
+      if: ${{ steps.first_test_run.outcome == 'success' }}
       run: |
         bundle exec rspec spec/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,4 +45,4 @@ jobs:
         bin/magma global_migrate
     - name: Run RSpec test suite
       run: |
-        rspec spec/
+        bundle exec rspec spec/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Run tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: password
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.5
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.5
+    - name: Setup deps and run RSpec test suite
+      env:
+        PGHOST: 127.0.0.1
+        PGUSER: postgres
+        MAGMA_ENV: test
+      run: |
+        gem install bundler -v 2.1.4
+        bundle install --jobs 4 --retry 3
+        bin/magma create_db labors
+        bin/magma migrate
+        bin/magma global_migrate
+        rspec spec/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ jobs:
       db:
         image: postgres
         env:
+          POSTGRES_USER: developer
           POSTGRES_PASSWORD: password
         ports: ['5432:5432']
         options: >-
@@ -23,7 +24,7 @@ jobs:
     - name: Setup deps and run RSpec test suite
       env:
         PGHOST: 127.0.0.1
-        PGUSER: postgres
+        PGUSER: developer
         MAGMA_ENV: test
       run: |
         gem install bundler -v 2.1.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         gem install bundler -v 2.1.4
         bundle install --jobs 4 --retry 3
+        cp config.yml.test config.yml
         bin/magma create_db labors
         bin/magma migrate
         bin/magma global_migrate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,11 @@ jobs:
         bin/magma create_db labors
         bin/magma migrate
         bin/magma global_migrate
-    - name: Run RSpec test suite
+    - name: Run test suite
+      id: first_test_run
+      run: |
+        bundle exec rspec spec/
+    - name: Run test suite again to detect flaky failures
+      if: ${{ steps.first_test_run.outcome == "success" }}
       run: |
         bundle exec rspec spec/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '~> 2.5'
 
 gem 'etna'
 gem 'pg'
-gem 'sequel', '4.49.0'
+gem 'sequel', '5.28.0'
 gem 'mini_magick'
 gem 'fog-aws'
 gem 'carrierwave-sequel'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.5.7'
+ruby '~> 2.5'
 
 gem 'etna'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     database_cleaner (1.8.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.8)
+    etna (0.1.11)
       jwt
       multipart-post
       net-http-persistent
@@ -76,7 +76,7 @@ GEM
     minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -85,7 +85,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (4.0.3)
-    rack (2.1.2)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.9.0)
@@ -141,7 +141,7 @@ DEPENDENCIES
   pry
   rack-test
   rspec
-  sequel (= 4.49.0)
+  sequel (= 5.28.0)
   simplecov
   spreadsheet
   timecop

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Run tests](https://github.com/mountetna/magma/workflows/Run%20tests/badge.svg)
+
 Magma is a data warehouse.
 
 Data comes into Magma via JSON api (the /update and /loader endpoints) and command-line data loaders.

--- a/config.yml.test
+++ b/config.yml.test
@@ -1,0 +1,19 @@
+---
+
+:test:
+  :db:
+    :database: magma_test
+    :host: localhost
+    :adapter: postgres
+    :user: developer
+    :password: password
+  :project_path: ./spec/labors/
+  :host: https://magma.test
+  :log_file: /dev/stdout
+  :hmac_keys:
+    :magma: haggis
+  :storage:
+    :provider: metis
+    :host: metis.test
+    :download_expiration: 1440
+    :upload_expiration: 720

--- a/config.yml.test
+++ b/config.yml.test
@@ -10,6 +10,7 @@
   :project_path: ./spec/labors/
   :host: https://magma.test
   :log_file: /dev/stdout
+  :log_level: error
   :hmac_keys:
     :magma: haggis
   :storage:

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -388,8 +388,9 @@ describe RetrieveController do
   context 'pagination' do
     it 'can page results' do
       labor_list = create_list(:labor, 9)
-      prize_list = create_list(:prize, 3, labor: labor_list[7])
-      names = labor_list.sort_by(&:name)[6..8].map(&:name)
+      third_page_labors = labor_list.sort_by(&:name)[6..8]
+      labor_with_prize = third_page_labors[1]
+      prize_list = create_list(:prize, 3, labor: labor_with_prize)
 
       retrieve(
         project_name: 'labors',
@@ -400,9 +401,11 @@ describe RetrieveController do
         page_size: 3
       )
 
+      names = third_page_labors.map(&:name).map(&:to_sym)
+
       expect(last_response.status).to eq(200)
-      expect(json_body[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
-      expect(json_body[:models][:labor][:documents][labor_list[7][:name].to_sym][:prize]).to match_array(prize_list.map(&:id))
+      expect(json_body[:models][:labor][:documents].keys).to eq(names)
+      expect(json_body[:models][:labor][:documents][labor_with_prize.name.to_sym][:prize]).to match_array(prize_list.map(&:id))
 
       # check to make sure collapse_tables doesn't mess things up
       retrieve(
@@ -416,8 +419,8 @@ describe RetrieveController do
       )
 
       expect(last_response.status).to eq(200)
-      expect(json_body[:models][:labor][:documents].keys).to eq(names.map(&:to_sym))
-      expect(json_body[:models][:labor][:documents][labor_list[7][:name].to_sym][:prize]).to eq(nil)
+      expect(json_body[:models][:labor][:documents].keys).to eq(names)
+      expect(json_body[:models][:labor][:documents][labor_with_prize.name.to_sym][:prize]).to eq(nil)
     end
 
     it 'can page results with joined collections' do


### PR DESCRIPTION
This PR sets up a GitHub Actions workflow that will run the test suite on every push and PR.

Here are a couple of example runs:
  * https://github.com/mountetna/magma/actions/runs/116143494
  * https://github.com/mountetna/magma/actions/runs/116903644

If you click on the "build" link on the left sidebar, you can see all the steps that happened for each run.

GitHub Actions also gives us a status badge that I've included in the [README](https://github.com/mountetna/magma/blob/c8bc242ad88e6892397aa175eaa782893398bef8/README.md).

## Magma changes

There are a few changes we had to make so GitHub Actions could run the test suite.

* Relax the Ruby version in the Gemfile because GitHub Actions only supports major.minor Ruby versioning. https://github.com/mountetna/magma/commit/100aa63cef4971741d6a4b2772ba6a0cd6b2b8fd
* Gemfile updates (https://github.com/mountetna/magma/commit/0ebad69c144c70e2222aaf68411cac3040416a0b)
  * Use the publicly released version of etna
  * Use the same version of sequel in both `Gemfile` and `Gemfile.lock`. Bundler uses the `Gemfile.lock` version (5.28.0).
* Add a `config.yml.test`. The workflow will copy that file to `config.yml` so it can boot magma.