### PR TITLE
Validate attributes exist in model tables

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -42,6 +42,10 @@ class Magma
       nil
     end
 
+    def missing_column?
+      !@model.columns.include?(@name)
+    end
+
     def validation_object
       @validation_object ||= Magma::ValidationObject.build(@validation&.symbolize_keys)
     end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -43,7 +43,7 @@ class Magma
     end
 
     def missing_column?
-      !@model.columns.include?(@name)
+      !@model.columns.include?(column_name)
     end
 
     def validation_object

--- a/lib/magma/attributes/child.rb
+++ b/lib/magma/attributes/child.rb
@@ -15,6 +15,11 @@ class Magma
         obj[ self_id ] = record.id
       end
     end
+
+    def missing_column?
+      false
+    end
+
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation
       def validate(value, &block)
         return if value.nil? || value.empty?

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -50,6 +50,11 @@ class Magma
 
       return new_ids.map do |id| [id] end
     end
+
+    def missing_column?
+      false
+    end
+
     class Validation < Magma::Validation::Attribute::BaseAttributeValidation
       def validate(value, &block)
         unless value.is_a?(Array)

--- a/lib/magma/attributes/link.rb
+++ b/lib/magma/attributes/link.rb
@@ -35,5 +35,9 @@ class Magma
     def link_identity
       link_model.attributes[link_model.identity]
     end
+
+    def missing_column?
+      false
+    end
   end
 end

--- a/lib/magma/attributes/link.rb
+++ b/lib/magma/attributes/link.rb
@@ -35,9 +35,5 @@ class Magma
     def link_identity
       link_model.attributes[link_model.identity]
     end
-
-    def missing_column?
-      false
-    end
   end
 end

--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -18,6 +18,10 @@ class Magma
     def update record, new_value
     end
 
+    def missing_column?
+      false
+    end
+
     class Validation < Magma::CollectionAttribute::Validation; end
   end
 end

--- a/spec/magma_spec.rb
+++ b/spec/magma_spec.rb
@@ -1,10 +1,8 @@
 require_relative '../lib/magma'
 require 'yaml'
 
-def disconnect_attribute model, att_name
-  att = model.attributes[att_name]
-  model.attributes[att_name] = nil
-  att
+def disconnect_attribute(model, att_name)
+  model.attributes.delete(att_name)
 end
 
 def reconnect_attribute model, att_name, value
@@ -41,6 +39,7 @@ describe Magma do
         expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
       end
     end
+
     context 'project model' do
       before(:each) do
         # Delete the constant
@@ -64,6 +63,7 @@ describe Magma do
         expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
       end
     end
+
     context 'orphan models' do
       before(:each) do
         # Unlink the labor model and prize model
@@ -77,6 +77,14 @@ describe Magma do
       it 'complains if there are orphan models' do
         expect{Magma.instance.validate_models}.to raise_error(Magma::ValidationError)
       end
+    end
+
+    it "raises an error if a model has an attribute that isn't backed by a column in the model's table" do
+      Labors::Monster.attributes[:size] = Magma::IntegerAttribute.new(:size, Labors::Monster, {})
+
+      expect{ Magma.instance.validate_models }.to raise_error(Magma::ValidationError)
+
+      Labors::Monster.attributes.delete(:size)
     end
   end
 end


### PR DESCRIPTION
To help make `Magma#validate_models` a little more digestible, I also moved Magma attribute validations into `#validate_attributes`.

Fixes #130