### PR TITLE
Update retrieve TSV spec

### DIFF
--- a/lib/magma/retrieval.rb
+++ b/lib/magma/retrieval.rb
@@ -32,6 +32,16 @@ class Magma
           !(att.is_a?(Magma::TableAttribute) && @collapse_tables)
         end
 
+        if @requested_attribute_names != "all"
+          attributes.sort_by! do |att|
+            if att.name == @model.identity
+              -1
+            else
+              @requested_attribute_names.index(att.name)
+            end
+          end
+        end
+
         # if there is no identifier, use the :id column
         if !@model.has_identifier?
           attributes.push(OpenStruct.new(name: :id))

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -136,8 +136,8 @@ describe RetrieveController do
       json = json_body
 
       # any model with an identifier returns all records
-      expect(json[:models][:labor][:documents].keys).to match(labors.map(&:name).map(&:to_sym))
-      expect(json[:models][:monster][:documents].keys).to match(monsters.map(&:name).map(&:to_sym))
+      expect(json[:models][:labor][:documents].keys).to match_array(labors.map(&:name).map(&:to_sym))
+      expect(json[:models][:monster][:documents].keys).to match_array(monsters.map(&:name).map(&:to_sym))
 
       # it does not return a model with no identifier
       expect(json[:models][:prize]).to be_nil

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -278,7 +278,7 @@ describe RetrieveController do
   context 'tsv format' do
     it 'can retrieve a TSV of data from the endpoint' do
       labor_list = create_list(:labor, 12)
-      required_atts = ['name', 'number', 'completed']
+      required_atts = ['name', 'completed', 'number']
       retrieve(
         model_name: 'labor',
         record_names: 'all',
@@ -288,7 +288,7 @@ describe RetrieveController do
       )
       header, *table = CSV.parse(last_response.body, col_sep: "\t")
 
-      expect(header).to match_array(required_atts)
+      expect(header).to eq(required_atts)
       expect(table.length).to eq(12)
     end
 

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -233,8 +233,8 @@ describe RetrieveController do
 
       # the labor documents are received with the table identifiers filled in
       expect(models[:labor][:documents].size).to eq(2)
-      expect(models[:labor][:documents][:'Nemean Lion'][:prize]).to eq(lion_prizes.map(&:id))
-      expect(models[:labor][:documents][:'Lernean Hydra'][:prize]).to eq(hydra_prizes.map(&:id))
+      expect(models[:labor][:documents][:'Nemean Lion'][:prize]).to match_array(lion_prizes.map(&:id))
+      expect(models[:labor][:documents][:'Lernean Hydra'][:prize]).to match_array(hydra_prizes.map(&:id))
 
       # the prize documents are also included
       expect(models[:prize][:documents].keys.sort.map(&:to_s)).to eq(selected_prize_ids)
@@ -358,7 +358,7 @@ describe RetrieveController do
       expect(last_response.status).to eq(200)
 
       labor_names = json_body[:models][:labor][:documents].values.map{|d| d[:name]}
-      expect(labor_names).to match(new_labors.map(&:name))
+      expect(labor_names).to match_array(new_labors.map(&:name))
     end
 
     it 'can filter on updated_at, created_at' do

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -288,7 +288,7 @@ describe RetrieveController do
       )
       header, *table = CSV.parse(last_response.body, col_sep: "\t")
 
-      expect(header).to eq(required_atts)
+      expect(header).to match_array(required_atts)
       expect(table.length).to eq(12)
     end
 


### PR DESCRIPTION
This fixes a flaky failure that happened after https://github.com/mountetna/magma/pull/151.

https://github.com/mountetna/magma/runs/721348936

I'm assuming the TSV header order doesn't matter, so I used the `match_array` helper to verify the header elements are present without worrying about the order. If the order matters, we can try something else.