### PR TITLE
Fix root route

### DIFF
--- a/lib/magma/server.rb
+++ b/lib/magma/server.rb
@@ -22,7 +22,7 @@ class Magma
     post '/update', as: :update, action: 'update#action', auth: { user: { can_edit?: :project_name } } 
 
     get '/' do
-      [ 200, {}, 'Magma On.' ]
+      [ 200, {}, [ 'Magma is available.' ] ]
     end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,14 +1,27 @@
-describe 'Magma::Server' do
+describe Magma::Server do
   include Rack::Test::Methods
 
   def app
     OUTER_APP
   end
 
-  it 'shows little at the root.' do
+  def retrieve(post, user_type=:viewer)
+    auth_header(user_type)
+    json_post(:retrieve, post)
+  end
+
+  it 'fails for non-users' do
+    get('/')
+
+    expect(last_response.status).to eq(401)
+  end
+
+  it 'shows magma is available for users' do
     auth_header(:viewer)
-    get '/'
-    expect(last_response).to(be_ok)
-    expect(last_response.body).to(eq('Magma On.'))
+    get('/')
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('Magma is available.')
   end
 end
+


### PR DESCRIPTION
Trying to view magma in the browser should give you a basic status message. Instead, you get a 503 because the rack format for the route '/' is broken! This PR repairs this issue.