### PR TITLE
Add /update_model API endpoint

### DIFF
--- a/lib/magma/actions/action_error.rb
+++ b/lib/magma/actions/action_error.rb
@@ -1,0 +1,15 @@
+class Magma
+  class ActionError
+    attr_reader :message, :source, :reason
+
+    def initialize(message:, source:, reason: nil)
+      @message = message  
+      @source = source
+      @reason = reason
+    end
+
+    def to_h
+      {message: message, source: source, reason: reason}
+    end
+  end
+end

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -31,6 +31,8 @@ class Magma
     def validate
       if attribute
         @action_params.except(:action_name, :model_name, :attribute_name).keys.all? do |option|
+          next if check_restricted_attributes(option)
+
           unless attribute.respond_to?(option)
             @errors << Magma::ActionError.new(message: "Attribute does not implement #{option}", source: @action_params.slice(:action_name, :model_name, :attribute_name))
           end
@@ -43,6 +45,16 @@ class Magma
 
     def errors
       @errors.map(&:to_h)
+    end
+
+    private
+
+    def check_restricted_attributes(option)
+      if option == :name || option == :new_attribute_name
+        @errors << Magma::ActionError.new(message: "#{option.to_s} cannot be changed", source: @action_params.slice(:action_name, :model_name, :attribute_name))
+        true
+      end
+      false
     end
   end
 end

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -1,7 +1,7 @@
 require 'magma/actions/action_error'
 
 class Magma
-  class UpdateAttribute
+  class UpdateAttributeAction
     def initialize(project_name, action_params = {})
       @project_name = project_name
       @action_params = action_params

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -1,0 +1,21 @@
+class Magma
+  class UpdateAttribute
+    def initialize(project_name, action_params = {})
+      @project_name = project_name
+      @action_params = action_params
+    end
+
+    def perform
+      model = Magma.instance.get_model(
+        @project_name,
+        @action_params[:model_name]
+      )
+
+      attribute = model.attributes[@action_params[:attribute_name].to_sym]
+
+      @action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS).each do |option, value|
+        attribute.update_option(option, value)
+      end
+    end
+  end
+end

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -6,15 +6,26 @@ class Magma
     end
 
     def perform
-      model = Magma.instance.get_model(
+      @action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS).each do |option, value|
+        attribute.update_option(option, value)
+      end
+    end
+
+    def model
+      @model ||= Magma.instance.get_model(
         @project_name,
         @action_params[:model_name]
       )
+    end
 
-      attribute = model.attributes[@action_params[:attribute_name].to_sym]
+    def attribute
+      @attribute ||= model.attributes[@action_params[:attribute_name].to_sym]
+    end
 
-      @action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS).each do |option, value|
-        attribute.update_option(option, value)
+    def validate
+      return false unless attribute
+      @action_params.except(:action_name, :model_name, :attribute_name).keys.all? do |option|
+        attribute.respond_to?(option)
       end
     end
   end

--- a/lib/magma/server.rb
+++ b/lib/magma/server.rb
@@ -22,7 +22,7 @@ class Magma
 
     post '/update', as: :update, action: 'update#action', auth: { user: { can_edit?: :project_name } } 
 
-    post '/update_model', action: 'update_model#action'
+    post '/update_model', action: 'update_model#action', auth: { user: { is_superuser?: :project_name } }
 
     get '/' do
       [ 200, {}, [ 'Magma is available.' ] ]

--- a/lib/magma/server.rb
+++ b/lib/magma/server.rb
@@ -4,6 +4,7 @@ require_relative '../magma'
 require_relative '../magma/server/retrieve'
 require_relative '../magma/server/query'
 require_relative '../magma/server/update'
+require_relative '../magma/server/update_model'
 
 class Magma
   class Server < Etna::Server
@@ -20,6 +21,8 @@ class Magma
     post '/query', as: :query, action: 'query#action', auth: { user: { can_view?: :project_name } }
 
     post '/update', as: :update, action: 'update#action', auth: { user: { can_edit?: :project_name } } 
+
+    post '/update_model', action: 'update_model#action'
 
     get '/' do
       [ 200, {}, [ 'Magma is available.' ] ]

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -4,7 +4,7 @@ require_relative '../actions/update_attribute'
 class UpdateModelController < Magma::Controller
   def action
     actions = @params[:actions].map do |action_params|
-      action_class = "Magma::#{action_params[:action_name].classify}".constantize
+      action_class = "Magma::#{action_params[:action_name].classify}Action".constantize
       action_class.new(@project_name, action_params)
     end
 

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -8,6 +8,13 @@ class UpdateModelController < Magma::Controller
       action_class.new(@project_name, action_params).perform
     end
 
-    success({}, 'application/json')
+    @payload = Magma::Payload.new
+
+    Magma.instance.get_project(@project_name).models.each do |model_name, model|
+      retrieval = Magma::Retrieval.new(model, [], "all")
+      @payload.add_model(model, retrieval.attribute_names)
+    end
+
+    return success(@payload.to_hash.to_json, 'application/json')
   end
 end

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -8,9 +8,7 @@ class UpdateModelController < Magma::Controller
       action_class.new(@project_name, action_params)
     end
 
-
-    if actions.all? { |action| action.validate } 
-      actions.each(&:perform)
+    if actions.all?(&:validate) && actions.all?(&:perform)
       @payload = Magma::Payload.new
 
       Magma.instance.get_project(@project_name).models.each do |model_name, model|
@@ -18,9 +16,9 @@ class UpdateModelController < Magma::Controller
         @payload.add_model(model, retrieval.attribute_names)
       end
 
-      return success(@payload.to_hash.to_json, 'application/json')
+      success(@payload.to_hash.to_json, 'application/json')
     else
-      failure({}, 'application/json')
+      failure(422, errors: actions.flat_map(&:errors))
     end
   end
 end

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -3,18 +3,24 @@ require_relative '../actions/update_attribute'
 
 class UpdateModelController < Magma::Controller
   def action
-    @params[:actions].each do |action_params|
+    actions = @params[:actions].map do |action_params|
       action_class = "Magma::#{action_params[:action_name].classify}".constantize
-      action_class.new(@project_name, action_params).perform
+      action_class.new(@project_name, action_params)
     end
 
-    @payload = Magma::Payload.new
 
-    Magma.instance.get_project(@project_name).models.each do |model_name, model|
-      retrieval = Magma::Retrieval.new(model, [], "all")
-      @payload.add_model(model, retrieval.attribute_names)
+    if actions.all? { |action| action.validate } 
+      actions.each(&:perform)
+      @payload = Magma::Payload.new
+
+      Magma.instance.get_project(@project_name).models.each do |model_name, model|
+        retrieval = Magma::Retrieval.new(model, [], "all")
+        @payload.add_model(model, retrieval.attribute_names)
+      end
+
+      return success(@payload.to_hash.to_json, 'application/json')
+    else
+      failure({}, 'application/json')
     end
-
-    return success(@payload.to_hash.to_json, 'application/json')
   end
 end

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -1,0 +1,13 @@
+require_relative 'controller'
+require_relative '../actions/update_attribute'
+
+class UpdateModelController < Magma::Controller
+  def action
+    @params[:actions].each do |action_params|
+      action_class = "Magma::#{action_params[:action_name].classify}".constantize
+      action_class.new(@project_name, action_params).perform
+    end
+
+    success({}, 'application/json')
+  end
+end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -5,6 +5,9 @@ describe UpdateModelController do
     OUTER_APP
   end
 
+  let(:proper_name) { 'name' }
+  let(:improper_name) { 'namex' }
+
   it "rejects requests from non-superusers" do
     auth_header(:editor)
 
@@ -25,13 +28,13 @@ describe UpdateModelController do
     auth_header(:superuser)
     json_post(:update_model, {
       project_name: "labors",
-      actions: [
+      actions: [{
         action_name: "update_attribute",
         model_name: "monster",
-        attribute_name: "name",
+        attribute_name: proper_name,
         description: "The monster's name",
         display_name: "NAME"
-      ]
+      }]
     })
 
     expect(last_response.status).to eq(200)
@@ -42,5 +45,38 @@ describe UpdateModelController do
     attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
     expect(attribute_json["desc"]).to eq("The monster's name")
     expect(attribute_json["display_name"]).to eq("NAME")
+  end
+
+  it "does not update attribute options with invalid attribute name" do
+    auth_header(:superuser)
+    json_post(:update_model, {
+      project_name: "labors",
+      actions: [{
+        action_name: "update_attribute",
+        model_name: "monster",
+        attribute_name: improper_name,
+        description: "The monster's name",
+        display_name: "NAME"
+      }]
+    })
+    
+    expect(last_response.status).to eq(500)
+  end
+
+
+  it "does not update attribute options with the incorrect data type" do
+    auth_header(:superuser)
+    json_post(:update_model, {
+      project_name: "labors",
+      actions: [{
+        action_name: "update_attribute",
+        model_name: "monster",
+        attribute_name: 123,
+        description: "The monster's name",
+        display_name: "NAME"
+      }]
+    })
+
+    expect(last_response.status).to eq(500)
   end
 end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -5,8 +5,24 @@ describe UpdateModelController do
     OUTER_APP
   end
 
-  it "updates attribute options" do
+  it "rejects requests from non-superusers" do
     auth_header(:editor)
+
+    json_post(:update_model, {
+      project_name: "labors",
+      actions: [
+        action_name: "update_attribute",
+        model_name: "monster",
+        attribute_name: "name",
+        description: "The monster's name",
+      ]
+    })
+
+    expect(last_response.status).to eq(403)
+  end
+
+  it "updates attribute options" do
+    auth_header(:superuser)
     json_post(:update_model, {
       project_name: "labors",
       actions: [

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -59,8 +59,10 @@ describe UpdateModelController do
         display_name: "NAME"
       }]
     })
-    
-    expect(last_response.status).to eq(500)
+
+    response_json = JSON.parse(last_response.body)
+    expect(last_response.status).to eq(422)
+    expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
   end
 
 
@@ -71,12 +73,15 @@ describe UpdateModelController do
       actions: [{
         action_name: "update_attribute",
         model_name: "monster",
-        attribute_name: 123,
-        description: "The monster's name",
-        display_name: "NAME"
+        attribute_name: proper_name,
+        description: 123,
+        display_name: "NAME",
+        hidden: 'something'
       }]
     })
 
-    expect(last_response.status).to eq(500)
+    response_json = JSON.parse(last_response.body)
+    expect(last_response.status).to eq(422)
+    expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
   end
 end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -21,5 +21,10 @@ describe UpdateModelController do
     expect(last_response.status).to eq(200)
     expect(Labors::Monster.attributes[:name].description).to eq("The monster's name")
     expect(Labors::Monster.attributes[:name].display_name).to eq("NAME")
+
+    response_json = JSON.parse(last_response.body)
+    attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
+    expect(attribute_json["desc"]).to eq("The monster's name")
+    expect(attribute_json["display_name"]).to eq("NAME")
   end
 end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -47,43 +47,97 @@ describe UpdateModelController do
     expect(attribute_json["display_name"]).to eq("NAME")
   end
 
-  it "does not update attribute options with invalid attribute name" do
-    auth_header(:superuser)
-    json_post(:update_model, {
-      project_name: "labors",
-      actions: [{
-        action_name: "update_attribute",
-        model_name: "monster",
-        attribute_name: improper_name,
-        description: "The monster's name",
-        display_name: "NAME"
-      }]
-    })
+  describe "does not update" do
+    it "does not update attribute options with invalid attribute name" do
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: improper_name,
+          description: "The monster's name",
+          display_name: "NAME"
+        }]
+      })
 
-    response_json = JSON.parse(last_response.body)
-    expect(last_response.status).to eq(422)
-    expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
-  end
+      response_json = JSON.parse(last_response.body)
+      expect(last_response.status).to eq(422)
+      expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
+    end
 
 
-  it "does not update attribute options with the incorrect data type" do
-    auth_header(:superuser)
-    json_post(:update_model, {
-      project_name: "labors",
-      actions: [{
-        action_name: "update_attribute",
-        model_name: "monster",
-        attribute_name: proper_name,
-        description: 123,
-        display_name: "NAME",
-        hidden: 'something'
-      }]
-    })
+    it "does not update attribute options with the incorrect data type" do
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: proper_name,
+          description: 123,
+          display_name: "NAME",
+          hidden: 'something'
+        }]
+      })
 
-    response_json = JSON.parse(last_response.body)
+      response_json = JSON.parse(last_response.body)
 
-    expect(last_response.status).to eq(422)
-    expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
-    expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
+      expect(last_response.status).to eq(422)
+      expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
+      expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
+    end
+
+    it "does not update attribute_name" do
+      expected = {
+        :message=>"new_attribute_name cannot be changed", 
+        :source=>{
+          :action_name=>"update_attribute", 
+          :model_name=>"monster", 
+          :attribute_name=>"name"
+        }, 
+        :reason=>nil
+      }
+
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: proper_name,
+          new_attribute_name: 'new_name'
+        }]
+      })
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors][0]).to eq(expected)
+    end
+
+    it "does not update name" do
+      expected = {
+        :message=>"name cannot be changed", 
+        :source=>{
+          :action_name=>"update_attribute", 
+          :model_name=>"monster", 
+          :attribute_name=>"name"
+        }, 
+        :reason=>nil
+      }
+
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: proper_name,
+          name: 'new_name'
+        }]
+      })
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors][0]).to eq(expected)
+    end
   end
 end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -1,0 +1,25 @@
+describe UpdateModelController do
+  include Rack::Test::Methods
+
+  def app
+    OUTER_APP
+  end
+
+  it "updates attribute options" do
+    auth_header(:editor)
+    json_post(:update_model, {
+      project_name: "labors",
+      actions: [
+        action_name: "update_attribute",
+        model_name: "monster",
+        attribute_name: "name",
+        description: "The monster's name",
+        display_name: "NAME"
+      ]
+    })
+
+    expect(last_response.status).to eq(200)
+    expect(Labors::Monster.attributes[:name].description).to eq("The monster's name")
+    expect(Labors::Monster.attributes[:name].display_name).to eq("NAME")
+  end
+end

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -81,7 +81,9 @@ describe UpdateModelController do
     })
 
     response_json = JSON.parse(last_response.body)
+
     expect(last_response.status).to eq(422)
     expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
+    expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -286,6 +286,9 @@ def json_document model, record_name
 end
 
 AUTH_USERS = {
+  superuser: {
+    email: 'zeus@twelve-labors.org', first: 'Zeus', perm: 'a:administration'
+  },
   editor: {
     email: 'eurystheus@twelve-labors.org', first: 'Eurystheus', perm: 'E:labors'
   },


### PR DESCRIPTION
This PR adds a /update_model API endpoint per #131. So far it supports updating an attribute's options.

The endpoint is backed by the newly added `UpdateModelController`. It will iterate over the array of actions it receives, and defer to action classes to perform those actions. For example, an `update_attribute` action will be performed by `Magma::UpdateAttribute`.

In addition to performing actions, each action class is responsible for validating its action params. This division of responsibilities will help keep `UpdateModelController` pretty stable as we add new actions. It will also make it easier for us to parallelize the work going forward.

We've also restricted the endpoint to superusers based on conversations we've had in the past. We can change the permissions if something else makes sense.