### PR TITLE
Extract logic from update_model_controller

### DIFF
--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -1,0 +1,36 @@
+require 'magma/actions/update_attribute'
+
+class Magma
+  class ModelUpdateActions
+    def self.build(project_name, actions_list)
+      new(project_name, actions_list) 
+    end
+
+    def perform
+      return false unless valid?
+      @actions.all?(&:perform)
+    end
+
+    def errors
+      @errors + @actions.flat_map(&:errors)
+    end
+
+    private
+
+    def valid?
+      @errors.empty? && @actions.all?(&:validate)
+    end
+
+    def initialize(project_name, actions_list)
+      @errors = []
+      @actions = []
+      actions_list.each do |action_params|
+        action_class = "Magma::#{action_params[:action_name].classify}Action".constantize
+        @actions << action_class.new(project_name, action_params)
+      rescue NameError => e
+        @errors << ActionError.new(message: "Invalid action type", source: action_params[:action_name]) 
+      end
+    end
+  end
+end
+

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -1,4 +1,4 @@
-require 'magma/actions/action_error'
+require_relative 'action_error'
 
 class Magma
   class UpdateAttributeAction
@@ -30,9 +30,8 @@ class Magma
 
     def validate
       if attribute
-        @action_params.except(:action_name, :model_name, :attribute_name).keys.all? do |option|
+        @action_params.except(:action_name, :model_name, :attribute_name).keys.each do |option|
           next if check_restricted_attributes(option)
-
           unless attribute.respond_to?(option)
             @errors << Magma::ActionError.new(message: "Attribute does not implement #{option}", source: @action_params.slice(:action_name, :model_name, :attribute_name))
           end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -15,7 +15,7 @@ class Magma
       :validation
     ]
 
-    attr_reader :name, :loader, :validation, :format_hint, :unique, :index, :restricted, :link_model_name, :description
+    attr_reader :name, :loader, :validation, :format_hint, :unique, :index, :restricted, :link_model_name, :description, :hidden
 
     class << self
       def options

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -1,24 +1,19 @@
 require_relative 'controller'
-require_relative '../actions/update_attribute'
+require 'magma/actions/model_update_actions'
 
 class UpdateModelController < Magma::Controller
   def action
-    actions = @params[:actions].map do |action_params|
-      action_class = "Magma::#{action_params[:action_name].classify}Action".constantize
-      action_class.new(@project_name, action_params)
-    end
+    model_update_actions = Magma::ModelUpdateActions.build(@project_name, @params[:actions])
 
-    if actions.all?(&:validate) && actions.all?(&:perform)
+    if model_update_actions.perform
       @payload = Magma::Payload.new
-
       Magma.instance.get_project(@project_name).models.each do |model_name, model|
         retrieval = Magma::Retrieval.new(model, [], "all")
         @payload.add_model(model, retrieval.attribute_names)
       end
-
       success(@payload.to_hash.to_json, 'application/json')
     else
-      failure(422, errors: actions.flat_map(&:errors))
+      failure(422, errors: model_update_actions.errors)
     end
   end
 end

--- a/lib/magma/server/update_model.rb
+++ b/lib/magma/server/update_model.rb
@@ -1,5 +1,5 @@
 require_relative 'controller'
-require 'magma/actions/model_update_actions'
+require_relative '../actions/model_update_actions'
 
 class UpdateModelController < Magma::Controller
   def action

--- a/spec/actions/model_update_actions_spec.rb
+++ b/spec/actions/model_update_actions_spec.rb
@@ -1,5 +1,3 @@
-require 'magma/actions/model_update_actions'
-
 describe Magma::ModelUpdateActions do
   let(:actions) do
     Magma::ModelUpdateActions.build(

--- a/spec/actions/model_updater_spec.rb
+++ b/spec/actions/model_updater_spec.rb
@@ -1,0 +1,78 @@
+require 'magma/actions/model_update_actions'
+
+describe Magma::ModelUpdateActions do
+  let(:actions) do
+    Magma::ModelUpdateActions.build(
+      "labors", 
+      [{
+        action_name: action_name,
+        model_name: "monster",
+        attribute_name: "name",
+        description: "The monster's name",
+        display_name: "NAME"
+      }]
+    )
+  end
+
+  describe '#perform' do
+    let(:action_name) { "update_attribute" }
+
+    describe 'with invalid action_name' do
+      let(:action_name) { "delete_everything" }
+
+      it 'produces an error with invalid names' do
+        expect(actions.perform).to eq(false)
+        expect(actions.errors.size).to eq(1)
+      end
+    end
+
+    describe 'with valid action_name' do
+      let(:update_attribute_action) { double('update_attribute') }
+      let(:validate_return) { true }
+      let(:perform_return) { true }
+      let(:action_errors) { [] }
+
+      before do
+        allow(Magma::UpdateAttributeAction).to receive(:new).and_return(update_attribute_action)
+        allow(update_attribute_action).to receive(:validate).and_return(validate_return)
+        allow(update_attribute_action).to receive(:perform).and_return(perform_return)
+        allow(update_attribute_action).to receive(:errors).and_return(action_errors)
+      end
+
+      it 'calls validate and peform' do
+        expect(actions.perform).to eq(true)
+        expect(update_attribute_action).to have_received(:validate).once
+        expect(update_attribute_action).to have_received(:perform).once
+        expect(actions.errors).to eq([])
+      end
+
+      describe 'when action#validate fails' do
+        let(:validate_return) { false } 
+
+        it 'perform fails and does not perform action' do
+          expect(actions.perform).to eq(false)
+          expect(update_attribute_action).to have_received(:validate).once
+          expect(update_attribute_action).not_to have_received(:perform)
+        end
+      end
+
+      describe 'when action#perform fails' do
+        let(:perform_return) { false }
+
+        it 'perform is called on action' do
+          expect(actions.perform).to eq(false)
+          expect(update_attribute_action).to have_received(:validate).once
+          expect(update_attribute_action).to have_received(:perform).once
+        end
+      end
+
+      describe '#errors' do
+        let(:action_errors) { [:oops] }
+
+        it 'returns action#errors' do
+          expect(actions.errors).to eq(action_errors)
+        end
+      end
+    end 
+  end
+end

--- a/spec/actions/update_attribute_actions_spec.rb
+++ b/spec/actions/update_attribute_actions_spec.rb
@@ -1,0 +1,83 @@
+describe Magma::UpdateAttributeAction do
+  let(:project_name) { 'labors' }
+  let(:action_params) do 
+    {
+      action_name: "update_attribute",
+      model_name: "monster",
+      attribute_name: "name",
+      description: value,
+      display_name: "NAME"
+    } 
+  end
+  
+  let(:update_attribute_action) { Magma::UpdateAttributeAction.new(project_name, action_params) }
+  let(:value) { "The monster's name" }
+
+  describe '#perform' do
+    let(:attribute) { Labors::Monster.attributes[:name] }
+    let(:option) { :description }
+
+    before do
+      allow(attribute).to receive(:update_option)
+    end
+
+    it 'updates the option and returns no errors' do
+      expect(update_attribute_action.perform).to eq(true)
+      expect(attribute).to have_received(:update_option).with(option, value).once
+      expect(update_attribute_action.errors).to be_empty
+    end
+
+    describe 'when update fails' do
+      before do
+        allow(attribute).to receive(:update_option).and_raise('oopsie')
+      end
+
+      it 'captures an update error' do
+        expect(update_attribute_action.perform).to eq(false)
+        expect(attribute).to have_received(:update_option).with(option, value).once
+        expect(update_attribute_action.errors).not_to be_empty
+      end
+    end
+  end
+
+  describe '#validate' do
+    it 'is valid with an attribute and valid update keys' do
+      expect(update_attribute_action.validate).to eq(true)
+    end
+
+    describe 'with no attribute' do
+      before { action_params.merge!(attribute_name: 'not_an_attribute') }
+
+      let(:errors) { update_attribute_action.errors }
+
+      it 'captures an attribute error' do
+        expect(update_attribute_action.validate).to eq(false)  
+        expect(errors.count).to eq(1)
+        expect(errors.first[:message]).to eq("Attribute does not exist")
+      end
+    end
+
+    describe 'when updating a non-existent field' do
+      before { action_params.merge!(age: 132) }
+
+      let(:errors) { update_attribute_action.errors }
+
+      it 'captures an attribute option error' do
+        expect(update_attribute_action.validate).to eq(false)
+        expect(errors.count).to eq(1)
+        expect(errors.first[:message]).to eq("Attribute does not implement age")
+      end
+    end
+  end
+
+  describe '#errors' do
+    let(:errors) { [:oops] }
+
+    before { allow(update_attribute_action).to receive(:errors).and_return(errors) }
+
+    it 'returns an array of errors' do
+      expect(update_attribute_action.errors).to eq(errors)
+    end
+  end
+
+end

--- a/spec/fixtures/movies/models/villain.rb
+++ b/spec/fixtures/movies/models/villain.rb
@@ -1,0 +1,5 @@
+module Movies
+  class Villain < Magma::Model
+    string :name, description: "The villain's name"
+  end
+end

--- a/spec/magma_project_spec.rb
+++ b/spec/magma_project_spec.rb
@@ -56,11 +56,12 @@ describe Magma::Project do
     end
 
     it "gives database model attributes precedence over those defined in Ruby" do
-      original_attribute = Labors::Monster.attributes[:name]
+      project = Magma::Project.new(project_dir: "./spec/fixtures/movies")
+      original_attribute = Movies::Villain.attributes[:name]
 
       Magma.instance.db[:attributes].insert(
-        project_name: "labors",
-        model_name: "monster",
+        project_name: "movies",
+        model_name: "villain",
         attribute_name: "name",
         type: "string",
         created_at: Time.now,
@@ -68,12 +69,12 @@ describe Magma::Project do
         description: "Only something I would know"
       )
 
-      project = Magma::Project.new(project_dir: "./labors")
-      attribute = Labors::Monster.attributes[:name]
+      project = Magma::Project.new(project_dir: "./spec/movies")
+      attribute = Movies::Villain.attributes[:name]
 
       expect(attribute.description).to eq("Only something I would know")
 
-      Labors::Monster.attributes[:name] = original_attribute
+      Movies::Villain.attributes[:name] = original_attribute
     end
 
     it "raises an error when the database has attributes for a model that doesn't exist" do

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -25,6 +25,8 @@ describe UpdateModelController do
   end
 
   it "updates attribute options" do
+    original_attribute = Labors::Monster.attributes[:name].dup
+
     auth_header(:superuser)
     json_post(:update_model, {
       project_name: "labors",
@@ -45,10 +47,14 @@ describe UpdateModelController do
     attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
     expect(attribute_json["desc"]).to eq("The monster's name")
     expect(attribute_json["display_name"]).to eq("NAME")
+
+    Labors::Monster.attributes[:name] = original_attribute
   end
 
   describe "does not update" do
     it "does not update attribute options with invalid attribute name" do
+      original_attribute = Labors::Monster.attributes[:name].dup
+
       auth_header(:superuser)
       json_post(:update_model, {
         project_name: "labors",
@@ -64,10 +70,13 @@ describe UpdateModelController do
       response_json = JSON.parse(last_response.body)
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
+
+      Labors::Monster.attributes[:name] = original_attribute
     end
 
-
     it "does not update attribute options with the incorrect data type" do
+      original_attribute = Labors::Monster.attributes[:name].dup
+
       auth_header(:superuser)
       json_post(:update_model, {
         project_name: "labors",
@@ -86,6 +95,8 @@ describe UpdateModelController do
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
       expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
+
+      Labors::Monster.attributes[:name] = original_attribute
     end
 
     it "does not update attribute_name" do


### PR DESCRIPTION
#164 

The `UpdateModelController` was overloaded with logic that made it difficult to test. The only way to properly test the controller was correctly parsing incoming parameters was with a request spec.

This change will allow unit and function tests to be written against the actions that are created. Errors bubble up from the base level, through the `ModelUpdateAction` and into the controller.