### PR TITLE
Test fixes

### DIFF
--- a/spec/fixtures/movies/models/villain.rb
+++ b/spec/fixtures/movies/models/villain.rb
@@ -1,0 +1,5 @@
+module Movies
+  class Villain < Magma::Model
+    string :name, description: "The villain's name"
+  end
+end

--- a/spec/magma_project_spec.rb
+++ b/spec/magma_project_spec.rb
@@ -56,11 +56,12 @@ describe Magma::Project do
     end
 
     it "gives database model attributes precedence over those defined in Ruby" do
-      original_attribute = Labors::Monster.attributes[:name]
+      project = Magma::Project.new(project_dir: "./spec/fixtures/movies")
+      original_attribute = Movies::Villain.attributes[:name]
 
       Magma.instance.db[:attributes].insert(
-        project_name: "labors",
-        model_name: "monster",
+        project_name: "movies",
+        model_name: "villain",
         attribute_name: "name",
         type: "string",
         created_at: Time.now,
@@ -68,12 +69,12 @@ describe Magma::Project do
         description: "Only something I would know"
       )
 
-      project = Magma::Project.new(project_dir: "./labors")
-      attribute = Labors::Monster.attributes[:name]
+      project = Magma::Project.new(project_dir: "./spec/movies")
+      attribute = Movies::Villain.attributes[:name]
 
       expect(attribute.description).to eq("Only something I would know")
 
-      Labors::Monster.attributes[:name] = original_attribute
+      Movies::Villain.attributes[:name] = original_attribute
     end
 
     it "raises an error when the database has attributes for a model that doesn't exist" do

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -25,6 +25,8 @@ describe UpdateModelController do
   end
 
   it "updates attribute options" do
+    original_attribute = Labors::Monster.attributes[:name].dup
+
     auth_header(:superuser)
     json_post(:update_model, {
       project_name: "labors",
@@ -45,10 +47,14 @@ describe UpdateModelController do
     attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
     expect(attribute_json["desc"]).to eq("The monster's name")
     expect(attribute_json["display_name"]).to eq("NAME")
+
+    Labors::Monster.attributes[:name] = original_attribute
   end
 
   describe "does not update" do
     it "does not update attribute options with invalid attribute name" do
+      original_attribute = Labors::Monster.attributes[:name].dup
+
       auth_header(:superuser)
       json_post(:update_model, {
         project_name: "labors",
@@ -64,10 +70,13 @@ describe UpdateModelController do
       response_json = JSON.parse(last_response.body)
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
+
+      Labors::Monster.attributes[:name] = original_attribute
     end
 
-
     it "does not update attribute options with the incorrect data type" do
+      original_attribute = Labors::Monster.attributes[:name].dup
+
       auth_header(:superuser)
       json_post(:update_model, {
         project_name: "labors",
@@ -86,6 +95,8 @@ describe UpdateModelController do
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
       expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
+
+      Labors::Monster.attributes[:name] = original_attribute
     end
 
     it "does not update attribute_name" do


### PR DESCRIPTION
https://github.com/mountetna/magma/commit/f56a5c0406b7ba7ebaf178307d6403abcd11bd07 resets attributes that get changed in tests. `Magma::Attribute#update_option` changes options in memory that persist between test runs. As a result, attribute changes in `UpdateModelController` spec can cause other tests to fail. For example, prior to this commit `rspec spec/server/update_model_spec.rb spec/magma_commands_spec.rb --seed 18642` would fail. Before we tackle the bigger challenges around global state, we can manually reset attributes that get changed.

https://github.com/mountetna/magma/commit/5fcbebab11292527cc723ef7424b9164898f3857 adds a new fixtures project called Movies that can be used to verify the behavior of projects with Ruby backed model definitions. This helps give us more confidence that production projects like Ipi that are still Ruby backed work.