### PR TITLE
Make Magma::Attribute inherit from Sequel::Model

### DIFF
--- a/lib/magma.rb
+++ b/lib/magma.rb
@@ -40,17 +40,11 @@ class Magma
     @db.extension :connection_validator
     @db.extension :pg_json
     @db.pool.connection_validation_timeout = -1
-
-    Sequel::Model.plugin :timestamps, update_on_create: true
-    Sequel::Model.require_valid_table = false
-    Sequel.extension :inflector
-
-    require_relative 'magma/attribute'
-    require_relative 'magma/model'
   end
 
   def load_models(validate = true)
     setup_db
+    setup_sequel
 
     @storage = Magma::Storage.setup
 
@@ -60,6 +54,14 @@ class Magma
     end
 
     validate_models if validate
+  end
+
+  def setup_sequel
+    Sequel::Model.plugin :timestamps, update_on_create: true
+    Sequel::Model.require_valid_table = false
+    Sequel.extension :inflector
+    require_relative 'magma/attribute'
+    require_relative 'magma/model'
   end
 
   class Magma::ValidationError < StandardError

--- a/lib/magma.rb
+++ b/lib/magma.rb
@@ -6,9 +6,7 @@ require_relative 'magma/validation'
 require_relative 'magma/validation_object'
 require_relative 'magma/loader'
 require_relative 'magma/migration'
-require_relative 'magma/attribute'
 require_relative 'magma/dictionary'
-require_relative 'magma/model'
 require_relative 'magma/revision'
 require_relative 'magma/commands'
 require_relative 'magma/payload'
@@ -42,6 +40,13 @@ class Magma
     @db.extension :connection_validator
     @db.extension :pg_json
     @db.pool.connection_validation_timeout = -1
+
+    Sequel::Model.plugin :timestamps, update_on_create: true
+    Sequel::Model.require_valid_table = false
+    Sequel.extension :inflector
+
+    require_relative 'magma/attribute'
+    require_relative 'magma/model'
   end
 
   def load_models(validate = true)

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -10,7 +10,16 @@ class Magma
 
     def perform
       attribute.update(@action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS))
-      @errors.empty?
+    rescue Sequel::ValidationFailed => e
+      @errors << Magma::ActionError.new(
+        message: 'Update attribute failed',
+        source: @action_params.slice(:attribute_name, :model_name),
+        reason: e
+      )
+
+      attribute.initial_values.keys.each { |name| attribute.reset_column(name) }
+    ensure
+      return @errors.empty?
     end
 
     def model

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -9,12 +9,8 @@ class Magma
     end
 
     def perform
-      @action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS).each do |option, value|
-        attribute.update_option(option, value)
-      rescue => e
-        @errors << Magma::ActionError.new(message: 'Update attribute failed', source: @action_params.slice(:attribute_name, :model_name), reason: e)
-      end
-      return @errors.empty?
+      attribute.update(@action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS))
+      @errors.empty?
     end
 
     def model

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -43,10 +43,6 @@ class Magma
 :format_hint, :loader, :link_model_name, :restricted]
       end
 
-      def set_attribute(name, model, options, attribute_class)
-        attribute_class.new(name, model, options)
-      end
-
       def attribute_type
         @attribute_type ||= name.match("Magma::(.*)Attribute")[1].underscore
       end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -34,7 +34,6 @@ class Magma
       :validation
     ]
 
-    attr_accessor :magma_model
     attr_reader :loader
 
     class << self
@@ -49,11 +48,20 @@ class Magma
     end
 
     def initialize(opts = {})
-      @magma_model = opts.delete(:magma_model)
-      @loader = opts.delete(:loader)
       # Some Ipi models set the group option but it doesn't seem to be used anywhere
       opts.delete(:group)
-      super
+
+      super(opts.except(:magma_model, :loader))
+      self.magma_model = opts[:magma_model]
+      @loader = opts[:loader]
+    end
+
+    def magma_model=(new_magma_model)
+      @magma_model = new_magma_model
+      after_magma_model_set
+    end
+
+    def after_magma_model_set
     end
 
     def name

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -19,6 +19,21 @@ class Magma
     set_primary_key [:project_name, :model_name, :attribute_name]
     unrestrict_primary_key
 
+    plugin :dirty
+    plugin :auto_validations
+
+    def validate
+      super
+      validate_validation_json
+    end
+
+    def validate_validation_json
+      return unless validation
+      validation_object
+    rescue => e
+      errors.add(:validation, "is not properly formatted")
+    end
+
     DISPLAY_ONLY = [:child, :collection]
 
     EDITABLE_OPTIONS = [

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -150,30 +150,6 @@ class Magma
       end
     end
 
-    def update_option(opt, new_value)
-      opt = opt.to_sym
-      return unless EDITABLE_OPTIONS.include?(opt)
-
-      database_value = new_value.is_a?(Hash) ? Sequel.pg_json_wrap(new_value) : new_value
-
-      Magma.instance.db[:attributes].
-        insert_conflict(
-          target: [:project_name, :model_name, :attribute_name],
-          update: { "#{opt}": database_value, updated_at: Time.now }
-        ).insert(
-          project_name: @magma_model.project_name.to_s,
-          model_name: @magma_model.model_name.to_s,
-          attribute_name: name.to_s,
-          type: self.class.attribute_type,
-          created_at: Time.now,
-          updated_at: Time.now,
-          "#{opt}": database_value
-        )
-
-      instance_variable_set("@#{opt}", new_value)
-      @validation_object = nil if opt == :validation
-    end
-
     private
 
     MAGMA_ATTRIBUTES = [

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -155,7 +155,7 @@ class Magma
     end
 
     def display_name
-      super || name.to_s.split(/_/).map(&:capitalize).join(' ')
+      super || (attribute_name && attribute_name.split(/_/).map(&:capitalize).join(' '))
     end
 
     def update_link(record, link)

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -54,6 +54,9 @@ class Magma
 
     def initialize(opts = {})
       @magma_model = opts.delete(:magma_model)
+      @loader = opts.delete(:loader)
+      # Some Ipi models set the group option but it doesn't seem to be used anywhere
+      opts.delete(:group)
       super
     end
 

--- a/lib/magma/attributes/child.rb
+++ b/lib/magma/attributes/child.rb
@@ -1,16 +1,6 @@
 class Magma
   class ChildAttribute < Attribute
     include Magma::Link
-    def initialize(opts = {})
-      super
-      set_one_to_one if @magma_model
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_one_to_one
-    end
-
     def json_for record
       record[name]
     end
@@ -34,7 +24,7 @@ class Magma
 
     private
 
-    def set_one_to_one
+    def after_magma_model_set
       @magma_model.one_to_one(attribute_name.to_sym)
     end
   end

--- a/lib/magma/attributes/child.rb
+++ b/lib/magma/attributes/child.rb
@@ -1,16 +1,21 @@
 class Magma
   class ChildAttribute < Attribute
     include Magma::Link
-    def initialize(name, model, opts)
-      model.one_to_one(name)
+    def initialize(opts = {})
       super
+      set_one_to_one if @magma_model
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_one_to_one
     end
 
     def json_for record
-      record[@name]
+      record[name]
     end
 
-    def update record, link
+    def update_record record, link
       link_model.update_or_create(link_model.identity => link) do |obj|
         obj[ self_id ] = record.id
       end
@@ -25,6 +30,12 @@ class Magma
         return if value.nil? || value.empty?
         link_validate(value, &block)
       end
+    end
+
+    private
+
+    def set_one_to_one
+      @magma_model.one_to_one(attribute_name.to_sym)
     end
   end
 end

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -1,16 +1,6 @@
 class Magma
   class CollectionAttribute < Attribute
     include Magma::Link
-    def initialize(opts = {})
-      super
-      set_one_to_many if @magma_model
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_one_to_many
-    end
-    
     def json_for record
       link = record[name]
       link ? link.map(&:last).sort : nil
@@ -73,7 +63,7 @@ class Magma
       end
     end
 
-    def set_one_to_many
+    def after_magma_model_set
       @magma_model.one_to_many(
         attribute_name.to_sym,
         class: @magma_model.project_model(attribute_name),

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -1,13 +1,18 @@
 class Magma
   class CollectionAttribute < Attribute
     include Magma::Link
-    def initialize(name, model, opts)
-      model.one_to_many(name, class: model.project_model(name), primary_key: :id)
+    def initialize(opts = {})
       super
+      set_one_to_many if @magma_model
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_one_to_many
     end
     
     def json_for record
-      link = record[@name]
+      link = record[name]
       link ? link.map(&:last).sort : nil
     end
 
@@ -15,8 +20,8 @@ class Magma
       json_for(record).join(", ")
     end
 
-    def update record, new_ids
-      old_links = record.send(@name)
+    def update_record record, new_ids
+      old_links = record.send(name)
 
       old_ids = old_links.map(&:identifier)
 
@@ -66,6 +71,14 @@ class Magma
           link_validate(link,&block)
         end
       end
+    end
+
+    def set_one_to_many
+      @magma_model.one_to_many(
+        attribute_name.to_sym,
+        class: @magma_model.project_model(attribute_name),
+        primary_key: :id
+      )
     end
   end
 end

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,17 +1,7 @@
 class Magma
   class FileAttribute < Attribute
-    def initialize(opts = {})
-      super
-      set_uploader if @magma_model
-    end
-
     def database_type
       String
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_uploader
     end
 
     def update_record(record, new_value)
@@ -23,7 +13,7 @@ class Magma
 
     private
 
-    def set_uploader
+    def after_magma_model_set
       file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
       Magma.instance.storage.setup_uploader(@magma_model, attribute_name, file_type)
     end

--- a/lib/magma/attributes/file.rb
+++ b/lib/magma/attributes/file.rb
@@ -1,42 +1,51 @@
 class Magma
   class FileAttribute < Attribute
-    def initialize(name, model, opts)
-      file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
-      Magma.instance.storage.setup_uploader(model, name, file_type) 
+    def initialize(opts = {})
       super
+      set_uploader if @magma_model
     end
 
     def database_type
       String
     end
 
-    def update(record, new_value)
+    def magma_model=(new_magma_model)
       super
-      record.modified!(@name)
+      set_uploader
+    end
 
-      return record[@name]
+    def update_record(record, new_value)
+      super
+      record.modified!(name)
+
+      return record[name]
     end
 
     private
 
+    def set_uploader
+      file_type = self.is_a?(Magma::ImageAttribute) ? :image : :file
+      Magma.instance.storage.setup_uploader(@magma_model, attribute_name, file_type)
+    end
+
     def filename(record, path)
       ext = path ? ::File.extname(path) : 'dat'
-      "#{@model.class.name.snake_case}-#{@attribute_name}-#{record.identifier}.#{ext}"
+      "#{@magma_model.class.name.snake_case}-#{attribute_name}-#{record.identifier}.#{ext}"
     end
 
     public
 
     def json_for record
-      path = record[@name]
+      path = record[name]
       return nil unless path
 
       path.is_a?(Array) ?
         {
-          upload_url: Magma.instance.storage.upload_url(@model.project_name, *path)
+          upload_url: Magma.instance.storage.upload_url(@magma_model.project_name, *path)
         }
         :
         {
-          url: Magma.instance.storage.download_url(@model.project_name, path),
+          url: Magma.instance.storage.download_url(@magma_model.project_name, path),
           path: File.basename(path)
         }
     end

--- a/lib/magma/attributes/foreign_key.rb
+++ b/lib/magma/attributes/foreign_key.rb
@@ -6,10 +6,10 @@ class Magma
     end
 
     def json_for record
-      record[@name]
+      record[name]
     end
 
-    def update record, link
+    def update_record record, link
       if link.nil?
         return record[ foreign_id ] = nil
       end

--- a/lib/magma/attributes/identifier_attribute.rb
+++ b/lib/magma/attributes/identifier_attribute.rb
@@ -1,9 +1,20 @@
 class Magma
   class IdentifierAttribute < StringAttribute
-    def initialize(name, model, opts)
-      super(name, model, opts.merge(unique: true))
-      model.identity = name
-      model.order(name) unless model.order
+    def initialize(opts = {})
+      super(opts.merge(unique: true))
+      set_identity if @magma_model
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_identity
+    end
+
+    private
+
+    def set_identity
+      @magma_model.identity = name
+      @magma_model.order(attribute_name) unless @magma_model.order
     end
   end
 end

--- a/lib/magma/attributes/identifier_attribute.rb
+++ b/lib/magma/attributes/identifier_attribute.rb
@@ -2,17 +2,11 @@ class Magma
   class IdentifierAttribute < StringAttribute
     def initialize(opts = {})
       super(opts.merge(unique: true))
-      set_identity if @magma_model
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_identity
     end
 
     private
 
-    def set_identity
+    def after_magma_model_set
       @magma_model.identity = name
       @magma_model.order(attribute_name) unless @magma_model.order
     end

--- a/lib/magma/attributes/image.rb
+++ b/lib/magma/attributes/image.rb
@@ -5,7 +5,7 @@ class Magma
 
       json && json[:url] ?
         json.merge(
-          thumb: Magma.instance.storage.download_url(@model.project_name, "thumb_#{record[@name]}")
+          thumb: Magma.instance.storage.download_url(@magma_model.project_name, "thumb_#{record[name]}")
         )
         : nil
     end

--- a/lib/magma/attributes/link.rb
+++ b/lib/magma/attributes/link.rb
@@ -1,27 +1,26 @@
 class Magma
   module Link
 
-    # In the event (during model creation) that we use the variable
-    # '@link_model' to set the model 'type' for a link, we need to use that
-    # variable for for model retrieval. Otherwise the '@name' variable will
-    # contain the appropriate model type for a link.
+    # In the event (during model creation) that we use link_model_name to set
+    # the model 'type' for a link, we need to use that variable for for model
+    # retrieval. Otherwise attribute_name will contain the appropriate model
+    # type for a link.
     def link_model
-      if @link_model_name
-        return Magma.instance.get_model(@model.project_name, @link_model_name)
-      else
-        return Magma.instance.get_model(@model.project_name, @name)
-      end
+      Magma.instance.get_model(
+        @magma_model.project_name,
+        link_model_name || attribute_name
+      )
     end
 
     def foreign_id
-      :"#{@name}_id"
+      :"#{attribute_name}_id"
     end
 
     # The model name has the project name appended to the front to form the
     # namespace. An example is 'Ipi::Sample'. Here we need to strip off the 
     # project name and append '_id'.
     def self_id
-      :"#{@model.name.snake_case.split('::')[1]}_id"
+      :"#{@magma_model.name.snake_case.split('::')[1]}_id"
     end
 
     def link_record(identifier)

--- a/lib/magma/attributes/link_attribute.rb
+++ b/lib/magma/attributes/link_attribute.rb
@@ -1,18 +1,8 @@
 class Magma
   class LinkAttribute < ForeignKeyAttribute
-    def initialize(opts = {})
-      super
-      set_link if @magma_model
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_link
-    end
-
     private
 
-    def set_link
+    def after_magma_model_set
       @magma_model.many_to_one(
         name,
         class: @magma_model.project_model(link_model_name || name)

--- a/lib/magma/attributes/link_attribute.rb
+++ b/lib/magma/attributes/link_attribute.rb
@@ -1,9 +1,22 @@
 class Magma
   class LinkAttribute < ForeignKeyAttribute
-    def initialize(name, model, opts)
-      model.many_to_one(name, class: model.project_model(opts[:link_model_name] || name))
-      super(name, model, opts)
+    def initialize(opts = {})
+      super
+      set_link if @magma_model
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_link
+    end
+
+    private
+
+    def set_link
+      @magma_model.many_to_one(
+        name,
+        class: @magma_model.project_model(link_model_name || name)
+      )
     end
   end
 end
-

--- a/lib/magma/attributes/matrix.rb
+++ b/lib/magma/attributes/matrix.rb
@@ -17,8 +17,8 @@ class Magma
       end
     end
 
-    def update(record, new_value)
-      record.set({@name=> new_value})
+    def update_record(record, new_value)
+      record.set({name=> new_value})
 
       cached_rows.delete(record.identifier)
       cached_rows_json.delete(record.identifier)
@@ -38,7 +38,7 @@ class Magma
       return if required_identifiers.empty?
 
       cached_rows.update(
-        @model.where( @model.identity => required_identifiers.to_a ).select_map( [ @model.identity, @name ] ).to_h
+        @magma_model.where( @magma_model.identity => required_identifiers.to_a ).select_map( [ @magma_model.identity, name ] ).to_h
       )
     end
 

--- a/lib/magma/attributes/parent_attribute.rb
+++ b/lib/magma/attributes/parent_attribute.rb
@@ -1,10 +1,21 @@
 class Magma
   class ParentAttribute < ForeignKeyAttribute
-    def initialize(name=nil, model, opts)
-      unless name.nil?
-        model.many_to_one(name)
-        super(name, model, opts)
+    def initialize(opts = {})
+      if opts[:attribute_name]
+        super
+        set_many_to_one if @magma_model
       end
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_many_to_one if attribute_name
+    end
+
+    private
+
+    def set_many_to_one
+      @magma_model.many_to_one(attribute_name.to_sym)
     end
   end
 end

--- a/lib/magma/attributes/parent_attribute.rb
+++ b/lib/magma/attributes/parent_attribute.rb
@@ -1,21 +1,10 @@
 class Magma
   class ParentAttribute < ForeignKeyAttribute
-    def initialize(opts = {})
-      if opts[:attribute_name]
-        super
-        set_many_to_one if @magma_model
-      end
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_many_to_one if attribute_name
-    end
-
     private
 
-    def set_many_to_one
-      @magma_model.many_to_one(attribute_name.to_sym)
+    def after_magma_model_set
+      return unless name
+      @magma_model.many_to_one(name)
     end
   end
 end

--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -1,13 +1,18 @@
 class Magma
   class TableAttribute < Attribute
     include Magma::Link
-    def initialize(name, model, opts)
-      model.one_to_many(name, class: model.project_model(name), primary_key: :id)
+    def initialize(opts = {})
       super
+      set_one_to_many if @magma_model
+    end
+
+    def magma_model=(new_magma_model)
+      super
+      set_one_to_many
     end
 
     def json_for record
-      link = record[@name]
+      link = record[name]
       link ? link.map(&:last) : nil
     end
 
@@ -15,7 +20,7 @@ class Magma
       nil
     end
 
-    def update record, new_value
+    def update_record record, new_value
     end
 
     def missing_column?
@@ -23,5 +28,15 @@ class Magma
     end
 
     class Validation < Magma::CollectionAttribute::Validation; end
+
+    private
+
+    def set_one_to_many
+      @magma_model.one_to_many(
+        attribute_name.to_sym,
+        class: @magma_model.project_model(attribute_name),
+        primary_key: :id
+      )
+    end
   end
 end

--- a/lib/magma/attributes/table.rb
+++ b/lib/magma/attributes/table.rb
@@ -1,16 +1,6 @@
 class Magma
   class TableAttribute < Attribute
     include Magma::Link
-    def initialize(opts = {})
-      super
-      set_one_to_many if @magma_model
-    end
-
-    def magma_model=(new_magma_model)
-      super
-      set_one_to_many
-    end
-
     def json_for record
       link = record[name]
       link ? link.map(&:last) : nil
@@ -31,7 +21,7 @@ class Magma
 
     private
 
-    def set_one_to_many
+    def after_magma_model_set
       @magma_model.one_to_many(
         attribute_name.to_sym,
         class: @magma_model.project_model(attribute_name),

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -1,7 +1,5 @@
 class Magma
-  Model = Class.new(Sequel::Model)
-   
-  class Model
+  class Model < Sequel::Model
     class << self
       Magma::Attribute.descendants.
         reject { |attribute| attribute == Magma::ForeignKeyAttribute }.
@@ -18,10 +16,9 @@ class Magma
 
       def load_attributes(attributes = {})
         attributes.each do |attribute|
-          attribute_name = attribute.attribute_name.to_sym
-          @parent = attribute_name if attribute.is_a?(Magma::ParentAttribute)
+          @parent = attribute.name if attribute.is_a?(Magma::ParentAttribute)
           attribute.magma_model = self
-          self.attributes[attribute_name] = attribute
+          self.attributes[attribute.name] = attribute
         end
       end
 

--- a/lib/magma/model.rb
+++ b/lib/magma/model.rb
@@ -6,9 +6,12 @@ class Magma
         each do |attribute|
           define_method attribute.attribute_type do |attribute_name=nil, opts={}|
             @parent = attribute_name if attribute == Magma::ParentAttribute
-            attributes[attribute_name] = attribute.new(
-              opts.merge(attribute_name: attribute_name, magma_model: self)
-            )
+            attributes[attribute_name] = attribute.new(opts.merge(
+              project_name: project_name,
+              model_name: model_name,
+              attribute_name: attribute_name,
+              magma_model: self
+            ))
           end
         end
 
@@ -46,7 +49,26 @@ class Magma
       # attributes point to pieces of data, including
       # records and collections of records
       def attributes
-        @attributes ||= {}
+        @attributes ||= base_attributes
+      end
+
+      def base_attributes
+        {
+          created_at: Magma::DateTimeAttribute.new(
+            attribute_name: :created_at,
+            project_name: project_name,
+            model_name: model_name,
+            magma_model: self,
+            hidden: true
+          ),
+          updated_at: Magma::DateTimeAttribute.new(
+            attribute_name: :updated_at,
+            project_name: project_name,
+            model_name: model_name,
+            magma_model: self,
+            hidden: true
+          )
+        }
       end
 
       def has_attribute?(name)
@@ -185,9 +207,6 @@ class Magma
         end
 
         super
-        %i(created_at updated_at).each do |timestamp|
-          magma_model.date_time(timestamp, {hidden: true})
-        end
       end
 
       # Sets the appropriate postgres schema for the model. There should be a

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -100,7 +100,7 @@ class Magma
       model_attributes = Magma::Attribute.
         where(project_name: @project_name.to_s).
         to_a.
-        group_by { |attribute| attribute[:model_name].to_sym }
+        group_by { |attribute| attribute.model_name.to_sym }
 
       model_attributes.each do |model_name, attributes|
         model = models[model_name]

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -97,7 +97,7 @@ class Magma
     end
 
     def load_model_attributes
-      model_attributes = Magma.instance.db[:attributes].
+      model_attributes = Magma::Attribute.
         where(project_name: @project_name.to_s).
         to_a.
         group_by { |attribute| attribute[:model_name].to_sym }

--- a/lib/magma/revision.rb
+++ b/lib/magma/revision.rb
@@ -47,7 +47,7 @@ class Magma
     def post!
       # update the record using this revision
       @revised_document.each do |name, new_value|
-        updated_record[name.to_sym] = @model.attributes[name.to_sym].update(@record, new_value)
+        updated_record[name.to_sym] = @model.attributes[name.to_sym].update_record(@record, new_value)
       end
       @record.save changed: true
 

--- a/spec/actions/update_attribute_actions_spec.rb
+++ b/spec/actions/update_attribute_actions_spec.rb
@@ -15,26 +15,25 @@ describe Magma::UpdateAttributeAction do
 
   describe '#perform' do
     let(:attribute) { Labors::Monster.attributes[:name] }
-    let(:option) { :description }
 
     before do
-      allow(attribute).to receive(:update_option)
+      allow(attribute).to receive(:update)
     end
 
     it 'updates the option and returns no errors' do
       expect(update_attribute_action.perform).to eq(true)
-      expect(attribute).to have_received(:update_option).with(option, value).once
+      expect(attribute).to have_received(:update).once
       expect(update_attribute_action.errors).to be_empty
     end
 
     describe 'when update fails' do
       before do
-        allow(attribute).to receive(:update_option).and_raise('oopsie')
+        allow(attribute).to receive(:update).and_raise(Sequel::ValidationFailed)
       end
 
       it 'captures an update error' do
         expect(update_attribute_action.perform).to eq(false)
-        expect(attribute).to have_received(:update_option).with(option, value).once
+        expect(attribute).to have_received(:update).once
         expect(update_attribute_action.errors).not_to be_empty
       end
     end

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -77,41 +77,6 @@ describe Magma::Attribute do
     end
   end
 
-  describe "#update_option" do
-    it "updates editable string backed options" do
-      model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, { description: "Old name" })
-
-      attribute.update_option(:description, "New name")
-
-      expect(attribute.description).to eq("New name")
-    end
-
-    it "updates editable JSON backed options" do
-      model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, {
-        validation: { type: "Array", value: [1, 2, 3] }
-      })
-
-      # Call attribute#validation_object to verify the cached validation_object
-      # gets reset
-      attribute.validation_object
-
-      attribute.update_option(:validation, { type: "Array", value: [4, 5, 6] })
-
-      expect(attribute.validation_object.options).to eq([4, 5, 6])
-    end
-
-    it "doesn't update non-editable options" do
-      model = double("model", project_name: :project, model_name: :model)
-      attribute = Magma::Attribute.new("name", model, {})
-
-      attribute.update_option(:loader, "foo")
-
-      expect(attribute.loader).to be_nil
-    end
-  end
-
   describe "#validation_object" do
     it "builds ArrayValidationObjects using validation options from the database" do
       attribute = Magma::StringAttribute.create(

--- a/spec/magma_child_attribute_spec.rb
+++ b/spec/magma_child_attribute_spec.rb
@@ -13,7 +13,7 @@ describe Magma::ChildAttribute do
     end
 
     it 'calls update or create on the link_model' do
-      child_attribute.update(record, link)
+      child_attribute.update_record(record, link)
 
       expect(link_model).to have_received(:update_or_create).once
     end

--- a/spec/magma_spec.rb
+++ b/spec/magma_spec.rb
@@ -80,7 +80,10 @@ describe Magma do
     end
 
     it "raises an error if a model has an attribute that isn't backed by a column in the model's table" do
-      Labors::Monster.attributes[:size] = Magma::IntegerAttribute.new(:size, Labors::Monster, {})
+      Labors::Monster.attributes[:size] = Magma::IntegerAttribute.new(
+        attribute_name: "size",
+        magma_model: Labors::Monster
+      )
 
       expect{ Magma.instance.validate_models }.to raise_error(Magma::ValidationError)
 

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -74,31 +74,6 @@ describe UpdateModelController do
       Labors::Monster.attributes[:name] = original_attribute
     end
 
-    it "does not update attribute options with the incorrect data type" do
-      original_attribute = Labors::Monster.attributes[:name].dup
-
-      auth_header(:superuser)
-      json_post(:update_model, {
-        project_name: "labors",
-        actions: [{
-          action_name: "update_attribute",
-          model_name: "monster",
-          attribute_name: proper_name,
-          description: 123,
-          display_name: "NAME",
-          hidden: 'something'
-        }]
-      })
-
-      response_json = JSON.parse(last_response.body)
-
-      expect(last_response.status).to eq(422)
-      expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
-      expect(response_json['errors'][0]['reason']).to include("PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type boolean:")
-
-      Labors::Monster.attributes[:name] = original_attribute
-    end
-
     it "does not update attribute_name" do
       expected = {
         :message=>"new_attribute_name cannot be changed", 

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -53,8 +53,6 @@ describe UpdateModelController do
 
   describe "does not update" do
     it "does not update attribute options with invalid attribute name" do
-      original_attribute = Labors::Monster.attributes[:name].dup
-
       auth_header(:superuser)
       json_post(:update_model, {
         project_name: "labors",
@@ -62,7 +60,6 @@ describe UpdateModelController do
           action_name: "update_attribute",
           model_name: "monster",
           attribute_name: improper_name,
-          description: "The monster's name",
           display_name: "NAME"
         }]
       })
@@ -71,7 +68,31 @@ describe UpdateModelController do
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
 
-      Labors::Monster.attributes[:name] = original_attribute
+      # Other options are not changed if an update fails
+      expect(Labors::Monster.attributes[:name].display_name).not_to eq("NAME")
+    end
+
+    it "does not update attribute options with the invalid data type" do
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: proper_name,
+          validation: 23,
+          display_name: "NAME"
+        }]
+      })
+
+      response_json = JSON.parse(last_response.body)
+
+      expect(last_response.status).to eq(422)
+      expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
+      expect(response_json['errors'][0]['reason']).to eq("validation is not properly formatted")
+
+      # Other options are not changed if an update fails
+      expect(Labors::Monster.attributes[:name].display_name).not_to eq("NAME")
     end
 
     it "does not update attribute_name" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ def load_labors_project
         attribute_name: attribute_name
       )
 
-      Magma::Attribute.create(row)
+      Magma.instance.db[:attributes].insert(row)
     end
   end
 end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -15,15 +15,13 @@ describe Magma::Validation do
   def stub_validation(model, att_name, new_validation)
     validation_stubs[model] ||= {}
     validation_stubs[model][att_name] = model.attributes[att_name].validation
-    model.attributes[att_name].instance_variable_set("@validation", new_validation)
-    model.attributes[att_name].instance_variable_set("@validation_object", nil)
+    model.attributes[att_name].validation = new_validation
   end
 
   def remove_validation_stubs
     validation_stubs.each do |model,atts|
       atts.each do |att_name, old_validation|
-        model.attributes[att_name].instance_variable_set("@validation", old_validation)
-        model.attributes[att_name].instance_variable_set("@validation_object", nil)
+        model.attributes[att_name].validation = old_validation
       end
     end
   end


### PR DESCRIPTION
By making `Magma::Attribute` inherit from `Sequel::Model`, we can leverage Sequel's API to manage data we get from the attributes table. This will help us avoid issues like https://github.com/mountetna/magma/pull/173#issuecomment-644144794 that come up from us trying to manage everything ourselves.

To get this to work, we have to make a number of changes. A few that stand out

  * Configure Sequel after connecting to the database so Sequel is available in both `Magma::Attribute` and `Magma::Model`
  * Use Sequel's [single table inheritance](http://sequel.jeremyevans.net/rdoc-plugins/classes/Sequel/Plugins/SingleTableInheritance.html) plugin to support `Magma::Attribute` subclasses (`Mamga::StringAttribute`, `Magma::IntegerAttribute`, etc.)
  * Rename `Magma::Attribute#model` to `#magma_model` because `#model` is used by `Sequel::Model`
  * Add `Magma::Attribute#after_magma_model_set` hook method because `Magma::Attribute`s fetched from the database don't get `magma_model`s when they're retrieved from the database.
  * Rename `Magma::Attribute#update` to `#update_record` because `#update` is used by `Sequel::Model`
  * Set `project_name` and `model_name` on `Magma::Attribute`s defined in Ruby. This makes it so we can call `#update` later to make changes.
    * To facilitate this, we can't set timestamp attributes in the `Magma::Model` inherited hook. https://github.com/mountetna/magma/commit/d1ac05a89092192f64085269b36114e3d5a9388c

This PR also makes some changes to loading the Labors project in `spec/spec_helper.rb` to make it clearer and more consistent.

Everything boots up with these changes locally, and I can click through the parts of Timur I know to make sure everything is working as it was before. I'd appreciate some more eyes to make sure I haven't broken something I don't know about 🙈