### PR TITLE
Load project models in the load_project command

### DIFF
--- a/lib/magma/dictionary.rb
+++ b/lib/magma/dictionary.rb
@@ -25,6 +25,7 @@ class Magma::Dictionary
 
   def to_hash
     {
+      dictionary_model: @dict_model_name,
       project_name: dict_model.project_name,
       model_name: dict_model.model_name,
       attributes: @attributes

--- a/spec/fixtures/template.json
+++ b/spec/fixtures/template.json
@@ -1,8 +1,9 @@
 {
   "models": {
-    "monster": {
+    "parent_model": {
       "template": {
-        "name": "monster",
+        "name": "parent_model",
+        "identifier": "name",
         "attributes": {
           "created_at": {
             "name": "created_at",
@@ -10,6 +11,8 @@
             "type": "DateTime",
             "attribute_class": "Magma::Attribute",
             "display_name": "Created At",
+            "restricted": false,
+            "read_only": false,
             "hidden": true,
             "validation": null,
             "attribute_type": "date_time"
@@ -20,17 +23,120 @@
             "type": "DateTime",
             "attribute_class": "Magma::Attribute",
             "display_name": "Updated At",
+            "restricted": false,
+            "read_only": false,
             "hidden": true,
             "validation": null,
             "attribute_type": "date_time"
           },
-          "labor": {
-            "name": "labor",
-            "attribute_name": "labor",
-            "model_name": "labor",
-            "link_model_name": "labor",
+          "name": {
+            "name": "name",
+            "attribute_name": "name",
+            "type": "String",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Name",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "identifier"
+          }
+        }
+      }
+    },
+    "model_one": {
+      "template": {
+        "name": "model_one",
+        "identifier": "name",
+        "attributes": {
+          "created_at": {
+            "name": "created_at",
+            "attribute_name": "created_at",
+            "type": "DateTime",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Created At",
+            "restricted": false,
+            "read_only": false,
+            "hidden": true,
+            "validation": null,
+            "attribute_type": "date_time"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "attribute_name": "updated_at",
+            "type": "DateTime",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Updated At",
+            "restricted": false,
+            "read_only": false,
+            "hidden": true,
+            "validation": null,
+            "attribute_type": "date_time"
+          },
+          "name": {
+            "name": "name",
+            "attribute_name": "name",
+            "type": "String",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Name",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "identifier"
+          },
+          "model_two": {
+            "name": "model_two",
+            "attribute_name": "model_two",
+            "model_name": "model_two",
+            "link_model_name": "model_two",
+            "attribute_class": "Magma::CollectionAttribute",
+            "display_name": "Model Two",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "collection"
+          }
+        }
+      }
+    },
+    "model_two": {
+      "template": {
+        "name": "model_two",
+        "identifier": "name",
+        "attributes": {
+          "created_at": {
+            "name": "created_at",
+            "attribute_name": "created_at",
+            "type": "DateTime",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Created At",
+            "restricted": false,
+            "read_only": false,
+            "hidden": true,
+            "validation": null,
+            "attribute_type": "date_time"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "attribute_name": "updated_at",
+            "type": "DateTime",
+            "attribute_class": "Magma::Attribute",
+            "display_name": "Updated At",
+            "restricted": false,
+            "read_only": false,
+            "hidden": true,
+            "validation": null,
+            "attribute_type": "date_time"
+          },
+          "parent_model": {
+            "name": "parent_model",
+            "attribute_name": "parent_model",
+            "model_name": "parent_model",
+            "link_model_name": "parent_model",
             "attribute_class": "Magma::ForeignKeyAttribute",
-            "display_name": "Labor",
+            "display_name": "ParentModel",
             "restricted": false,
             "read_only": false,
             "hidden": false,
@@ -65,32 +171,6 @@
             },
             "attribute_type": "string"
           },
-          "victim": {
-            "name": "victim",
-            "attribute_name": "victim",
-            "model_name": "victim",
-            "link_model_name": "victim",
-            "attribute_class": "Magma::CollectionAttribute",
-            "display_name": "Victim",
-            "restricted": false,
-            "read_only": false,
-            "hidden": false,
-            "validation": null,
-            "attribute_type": "collection"
-          },
-          "aspect": {
-            "name": "aspect",
-            "attribute_name": "aspect",
-            "model_name": "aspect",
-            "link_model_name": "aspect",
-            "attribute_class": "Magma::CollectionAttribute",
-            "display_name": "Aspect",
-            "restricted": false,
-            "read_only": false,
-            "hidden": false,
-            "validation": null,
-            "attribute_type": "collection"
-          },
           "stats": {
             "name": "stats",
             "attribute_name": "stats",
@@ -104,8 +184,18 @@
             "attribute_type": "file"
           }
         },
-        "identifier": "name",
-        "parent": "labor"
+        "parent": "parent_model",
+        "dictionary": {
+          "dictionary_model": "Labors::Codex",
+          "project_name": "labors",
+          "model_name": "codex",
+          "attributes": {
+            "monster": "monster",
+            "name": "aspect",
+            "source": "tome",
+            "value": "lore"
+          }
+        }
       }
     }
   }

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -53,6 +53,7 @@ describe RetrieveController do
 
     # the dictionary model is reported
     expect(json_template[:dictionary]).to eq(
+      dictionary_model: "Labors::Codex",
       project_name: 'labors',
       model_name: 'codex',
       attributes: {monster: 'monster', name: 'aspect', source: 'tome', value: 'lore'}


### PR DESCRIPTION
There's a little weirdness around loading model dictionaries from the template file because the model dictionary JSON is represented differently in the models table and the models JSON template.

In the models table, it looks like

https://github.com/mountetna/magma/blob/ef767145c933f0186474a3efce27b7170693be8e/spec/fixtures/labors_model_attributes.yml#L2

and in the template file it looks like

https://github.com/mountetna/magma/blob/0f5b7daf56417fc35fd0b60dbdd670b524d0c831/spec/fixtures/template.json#L188-L198

I added `dictionary_model` to the template so we can properly insert model dictionaries in `load_project`. So we can work around the dictionary JSON formats being different, but it might be worth consolidating it so it's consistent.

This PR also does a little bit of clean up on the command. It also updates the test so it runs against a new project that isn't already loaded by the test suite to make sure we're testing the command's behavior. 

Fixes #150 