### PR TITLE
Support add_model in /update_model API

### DIFF
--- a/lib/magma/actions/add_attribute.rb
+++ b/lib/magma/actions/add_attribute.rb
@@ -43,7 +43,7 @@ class Magma
     end
 
     def validate_attribute_name_unique
-      return if !model.has_attribute?(attribute.attribute_name)
+      return if !model&.has_attribute?(attribute.attribute_name)
 
       @errors << Magma::ActionError.new(
         message: "attribute_name already exists on #{model.name}",

--- a/lib/magma/actions/add_model.rb
+++ b/lib/magma/actions/add_model.rb
@@ -47,7 +47,7 @@ class Magma
 
     def validate_required_fields
       required_fields.each do |field|
-        validate_pressence(field)
+        validate_presence(field)
         validate_snake_case(field)
       end
     end
@@ -58,7 +58,7 @@ class Magma
       fields
     end
 
-    def validate_pressence(field)
+    def validate_presence(field)
       return if @action_params[field] && @action_params[field] != ""
 
       @errors << Magma::ActionError.new(

--- a/lib/magma/actions/add_model.rb
+++ b/lib/magma/actions/add_model.rb
@@ -1,0 +1,37 @@
+class Magma
+  class AddModelAction < BaseAction
+    def perform
+      Magma.instance.db[:models].insert(
+        project_name: @project_name,
+        model_name: @action_params[:model_name]
+      )
+
+      model = project.load_model(
+        project_name: @project_name,
+        model_name: @action_params[:model_name]
+      )
+
+      project.models[model.model_name] = model
+
+      if @action_params[:parent_link_type] != "table"
+        model.identifier(@action_params[:identifier].to_sym).save
+      end
+
+      model.parent(@action_params[:parent_model_name].to_sym).save
+
+      parent_model = Magma.instance.get_model(
+        @project_name,
+        @action_params[:parent_model_name]
+      )
+
+      parent_link = parent_model.send(
+        @action_params[:parent_link_type],
+        model.model_name
+      )
+
+      parent_link.save
+
+      true
+    end
+  end
+end

--- a/lib/magma/actions/add_model.rb
+++ b/lib/magma/actions/add_model.rb
@@ -1,37 +1,109 @@
 class Magma
   class AddModelAction < BaseAction
     def perform
-      Magma.instance.db[:models].insert(
-        project_name: @project_name,
-        model_name: @action_params[:model_name]
-      )
+      model = create_model
 
-      model = project.load_model(
-        project_name: @project_name,
-        model_name: @action_params[:model_name]
-      )
-
-      project.models[model.model_name] = model
-
-      if @action_params[:parent_link_type] != "table"
+      if !table_parent_link?
         model.identifier(@action_params[:identifier].to_sym).save
       end
 
       model.parent(@action_params[:parent_model_name].to_sym).save
 
-      parent_model = Magma.instance.get_model(
-        @project_name,
-        @action_params[:parent_model_name]
-      )
+      project.models[model.model_name] = model
 
-      parent_link = parent_model.send(
-        @action_params[:parent_link_type],
-        model.model_name
-      )
-
-      parent_link.save
+      parent_model.
+        send(@action_params[:parent_link_type], model.model_name).
+        save
 
       true
+    end
+
+    private
+
+    def create_model
+      Magma.instance.db[:models].insert(
+        project_name: @project_name,
+        model_name: @action_params[:model_name]
+      )
+
+      project.load_model(
+        project_name: @project_name,
+        model_name: @action_params[:model_name]
+      )
+    end
+
+    def validations
+      [
+        :validate_required_fields,
+        :validate_parent_model,
+        :validate_parent_link_type
+      ]
+    end
+
+    def validate_required_fields
+      required_fields.each do |field|
+        validate_pressence(field)
+        validate_snake_case(field)
+      end
+    end
+
+    def required_fields
+      fields = [:model_name, :parent_model_name, :parent_link_type]
+      fields << :identifier unless table_parent_link?
+      fields
+    end
+
+    def validate_pressence(field)
+      return if @action_params[field] && @action_params[field] != ""
+
+      @errors << Magma::ActionError.new(
+        message: "#{field} is required",
+        source: @action_params.slice(field)
+      )
+    end
+
+    def validate_snake_case(field)
+      return if @action_params[field]&.snake_case == @action_params[field]
+
+      @errors << Magma::ActionError.new(
+        message: "#{field} must be snake_case",
+        source: @action_params.slice(field)
+      )
+    end
+
+    def validate_parent_model
+      return if parent_model
+
+      @errors << Magma::ActionError.new(
+        message: "parent_model_name does not match a model",
+        source: @action_params.slice(:parent_model_name)
+      )
+    end
+
+    def validate_parent_link_type
+      return if PARENT_LINK_TYPES.include?(@action_params[:parent_link_type])
+
+      @errors << Magma::ActionError.new(
+        message: "parent_link_type must be one of #{PARENT_LINK_TYPES.join(', ')}",
+        source: @action_params.slice(:parent_model_name)
+      )
+    end
+
+    def table_parent_link?
+      @action_params[:parent_link_type] == "table"
+    end
+
+    PARENT_LINK_TYPES = ["child", "collection", "table"]
+
+    def parent_model
+      @parent_model ||= begin
+        Magma.instance.get_model(
+          @project_name,
+          @action_params[:parent_model_name]
+        )
+      rescue NameError
+        nil
+      end
     end
   end
 end

--- a/lib/magma/actions/add_model.rb
+++ b/lib/magma/actions/add_model.rb
@@ -1,21 +1,26 @@
 class Magma
   class AddModelAction < BaseAction
     def perform
-      model = create_model
+      @model = create_model
 
       if !table_parent_link?
-        model.identifier(@action_params[:identifier].to_sym).save
+        @model.identifier(@action_params[:identifier].to_sym).save
       end
 
-      model.parent(@action_params[:parent_model_name].to_sym).save
+      @model.parent(@action_params[:parent_model_name].to_sym).save
 
-      project.models[model.model_name] = model
+      project.models[@model.model_name] = @model
 
       parent_model.
-        send(@action_params[:parent_link_type], model.model_name).
+        send(@action_params[:parent_link_type], @model.model_name).
         save
 
       true
+    end
+
+    def rollback
+      parent_model.attributes.delete(@model.model_name)
+      project.unload_model(@model.model_name)
     end
 
     private

--- a/lib/magma/actions/base_action.rb
+++ b/lib/magma/actions/base_action.rb
@@ -33,5 +33,9 @@ class Magma
     def validations
       []
     end
+
+    def project
+      @project ||= Magma.instance.get_project(@project_name)
+    end
   end
 end

--- a/lib/magma/actions/base_action.rb
+++ b/lib/magma/actions/base_action.rb
@@ -11,7 +11,6 @@ class Magma
     def validate
       validations.each do |validation|
         send(validation)
-        break if @errors.any?
       end
 
       @errors.empty?

--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -19,8 +19,17 @@ class Magma
         update_model_tables
         true
       end
-    rescue
+    rescue => e
       @actions.each(&:rollback)
+
+      if @errors.empty?
+        @errors << Magma::ActionError.new(
+          message: "Unexpected error",
+          source: nil,
+          reason: e
+        )
+      end
+
       false
     end
 

--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -1,6 +1,7 @@
 require_relative 'base_action'
 require_relative 'update_attribute'
 require_relative 'add_attribute'
+require_relative 'add_model'
 
 class Magma
   class ModelUpdateActions

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -17,7 +17,7 @@ class Magma
     private
 
     def validations
-      [:validate_attribute_exists, :validate_options]
+      [:validate_attribute_exists, :validate_options, :validate_changes]
     end
 
     def validate_attribute_exists
@@ -44,6 +44,20 @@ class Magma
             source: @action_params.slice(:action_name, :model_name, :attribute_name)
           )
         end
+      end
+    end
+
+    def validate_changes
+      return unless attribute
+      validation_attribute = attribute.dup
+      validation_attribute.set(@action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS))
+      return if validation_attribute.valid?
+
+      validation_attribute.errors.full_messages.each do |error|
+        @errors << Magma::ActionError.new(
+          message: error,
+          source: @action_params.slice(:model_name, :attribute_name)
+        )
       end
     end
 

--- a/lib/magma/actions/update_attribute.rb
+++ b/lib/magma/actions/update_attribute.rb
@@ -30,6 +30,8 @@ class Magma
     end
 
     def validate_options
+      return unless attribute
+
       @action_params.except(:action_name, :model_name, :attribute_name).keys.each do |option|
         if restricted_options.include?(option)
           @errors << Magma::ActionError.new(

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -52,6 +52,19 @@ class Magma
       ([ models[:project] ] + ordered_models(models[:project])).map(&:migration).reject(&:empty?)
     end
 
+    def load_model(model_data)
+      model_class = Class.new(Magma::Model) do
+        set_schema(
+          model_data[:project_name].to_sym,
+          model_data[:model_name].pluralize.to_sym
+        )
+
+        dictionary(model_data[:dictionary].symbolize_keys) if model_data[:dictionary]
+      end
+
+      project_container.const_set(model_data[:model_name].classify, model_class)
+    end
+
     private
 
     def project_container
@@ -82,18 +95,7 @@ class Magma
     def load_models
       Magma.instance.db[:models].where(project_name: @project_name.to_s).
         reject { |model| project_container.const_defined?(model[:model_name].classify) }.
-        each do |model|
-          model_class = Class.new(Magma::Model) do
-            set_schema(
-              model[:project_name].to_sym,
-              model[:model_name].pluralize.to_sym
-            )
-
-            dictionary(model[:dictionary].symbolize_keys) if model[:dictionary]
-          end
-
-          project_container.const_set(model[:model_name].classify, model_class)
-        end
+        each { |model| load_model(model) }
     end
 
     def load_model_attributes

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -65,6 +65,11 @@ class Magma
       project_container.const_set(model_data[:model_name].classify, model_class)
     end
 
+    def unload_model(model_name)
+      models.delete(model_name)
+      project_container.send(:remove_const, model_name.to_s.classify)
+    end
+
     private
 
     def project_container

--- a/spec/actions/add_attribute_actions_spec.rb
+++ b/spec/actions/add_attribute_actions_spec.rb
@@ -26,7 +26,7 @@ describe Magma::AddAttributeAction do
     context "when it succeeds" do
       after do
         # Clear out new test attributes that are cached in memory
-        Labors::Monster.attributes.delete(attribute_name.to_sym)
+        action.rollback
       end
 
       it 'adds a new attribute and returns no errors' do
@@ -130,6 +130,17 @@ describe Magma::AddAttributeAction do
         expect(action.validate).to eq(false)
         expect(action.errors.first[:message]).to eq("Attribute does not implement foo")
       end
+    end
+  end
+
+  describe "#rollback" do
+    before do
+      action.perform
+    end
+
+    it "rolls back in memory changes" do
+      action.rollback
+      expect(Labors::Monster.attributes.keys).not_to include(attribute_name.to_sym)
     end
   end
 end

--- a/spec/actions/add_model_action_spec.rb
+++ b/spec/actions/add_model_action_spec.rb
@@ -83,4 +83,73 @@ describe Magma::AddModelAction do
       end
     end
   end
+
+  describe "#validate" do
+    context "when a required field is missing" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          identifier: "name",
+          parent_model_name: "labor",
+          parent_link_type: "child"
+        }
+      end
+
+      it "returns false and adds an error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("model_name is required")
+      end
+    end
+
+    context "when a required field is not snake_case" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          identifier: "name",
+          model_name: "newChildModel",
+          parent_model_name: "labor",
+          parent_link_type: "child"
+        }
+      end
+
+      it "returns false and adds an error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("model_name must be snake_case")
+      end
+    end
+
+    context "when the parent model doesn't exist" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          model_name: "new_child_model",
+          identifier: "name",
+          parent_model_name: "houdini",
+          parent_link_type: "child"
+        }
+      end
+
+      it "returns false and adds an error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("parent_model_name does not match a model")
+      end
+    end
+
+    context "when parent_link_type is incorrect" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          model_name: "new_child_model",
+          identifier: "name",
+          parent_model_name: "labor",
+          parent_link_type: "grandchild"
+        }
+      end
+
+      it "returns false and adds an error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("parent_link_type must be one of child, collection, table")
+      end
+    end
+  end
 end

--- a/spec/actions/add_model_action_spec.rb
+++ b/spec/actions/add_model_action_spec.rb
@@ -1,0 +1,86 @@
+describe Magma::AddModelAction do
+  let(:action) { Magma::AddModelAction.new("labors", action_params) }
+
+  describe "#perform" do
+    context "for child/collection parent_link_type" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          model_name: "new_child_model",
+          identifier: "name",
+          parent_model_name: "labor",
+          parent_link_type: "child"
+        }
+      end
+
+      after do
+        # Remove test model and link relationships from memory
+        project = Magma.instance.get_project(:labors)
+        project.models.delete(:new_child_model)
+        Labors.send(:remove_const, :NewChildModel)
+        Labors::Labor.attributes.delete(:new_child_model)
+      end
+
+      it "adds the model and defines link relationships" do
+        expect(action.perform).to eq(true)
+
+        expect(
+          Magma.instance.db[:models].
+            where(project_name: "labors", model_name: "new_child_model")
+        ).not_to be_nil
+
+        expect { Labors::NewChildModel }.not_to raise_error(NameError)
+
+        identifier = Labors::NewChildModel.attributes[:name]
+        expect(identifier).to be_a(Magma::IdentifierAttribute)
+        expect(identifier).not_to be_new
+
+        parent = Labors::NewChildModel.attributes[:labor]
+        expect(parent).to be_a(Magma::ParentAttribute)
+        expect(parent).not_to be_new
+
+        parent_link = Labors::Labor.attributes[:new_child_model]
+        expect(parent_link).to be_a(Magma::ChildAttribute)
+        expect(parent_link).not_to be_new
+      end
+    end
+
+    context "for table parent_link_type" do
+      let(:action_params) do
+        {
+          action_name: "add_attribute",
+          model_name: "new_table_model",
+          parent_model_name: "labor",
+          parent_link_type: "table"
+        }
+      end
+
+      after do
+        # Remove test model and link relationships from memory
+        project = Magma.instance.get_project(:labors)
+        project.models.delete(:new_table_model)
+        Labors.send(:remove_const, :NewTableModel)
+        Labors::Labor.attributes.delete(:new_table_model)
+      end
+
+      it "adds the model and defines link relationships" do
+        expect(action.perform).to eq(true)
+
+        expect(
+          Magma.instance.db[:models].
+            where(project_name: "labors", model_name: "new_table_model")
+        ).not_to be_nil
+
+        expect { Labors::NewTableModel }.not_to raise_error(NameError)
+
+        parent = Labors::NewTableModel.attributes[:labor]
+        expect(parent).to be_a(Magma::ParentAttribute)
+        expect(parent).not_to be_new
+
+        parent_link = Labors::Labor.attributes[:new_table_model]
+        expect(parent_link).to be_a(Magma::TableAttribute)
+        expect(parent_link).not_to be_new
+      end
+    end
+  end
+end

--- a/spec/actions/add_model_action_spec.rb
+++ b/spec/actions/add_model_action_spec.rb
@@ -5,7 +5,7 @@ describe Magma::AddModelAction do
     context "for child/collection parent_link_type" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           model_name: "new_child_model",
           identifier: "name",
           parent_model_name: "labor",
@@ -45,7 +45,7 @@ describe Magma::AddModelAction do
     context "for table parent_link_type" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           model_name: "new_table_model",
           parent_model_name: "labor",
           parent_link_type: "table"
@@ -82,7 +82,7 @@ describe Magma::AddModelAction do
     context "when a required field is missing" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           identifier: "name",
           parent_model_name: "labor",
           parent_link_type: "child"
@@ -98,7 +98,7 @@ describe Magma::AddModelAction do
     context "when a required field is not snake_case" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           identifier: "name",
           model_name: "newChildModel",
           parent_model_name: "labor",
@@ -115,7 +115,7 @@ describe Magma::AddModelAction do
     context "when the parent model doesn't exist" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           model_name: "new_child_model",
           identifier: "name",
           parent_model_name: "houdini",
@@ -132,7 +132,7 @@ describe Magma::AddModelAction do
     context "when parent_link_type is incorrect" do
       let(:action_params) do
         {
-          action_name: "add_attribute",
+          action_name: "add_model",
           model_name: "new_child_model",
           identifier: "name",
           parent_model_name: "labor",
@@ -150,7 +150,7 @@ describe Magma::AddModelAction do
   describe "#rollback" do
     let(:action_params) do
       {
-        action_name: "add_attribute",
+        action_name: "add_model",
         model_name: "new_child_model",
         identifier: "name",
         parent_model_name: "labor",

--- a/spec/actions/model_update_actions_spec.rb
+++ b/spec/actions/model_update_actions_spec.rb
@@ -76,7 +76,7 @@ describe Magma::ModelUpdateActions do
       end
     end
 
-    context "when an action fails", disable_database_cleaner_transaction: true do
+    context "when an action fails" do
       let(:actions) do
         Magma::ModelUpdateActions.build(
           "labors",

--- a/spec/server/update_model_spec.rb
+++ b/spec/server/update_model_spec.rb
@@ -5,53 +5,56 @@ describe UpdateModelController do
     OUTER_APP
   end
 
-  let(:proper_name) { 'name' }
-  let(:improper_name) { 'namex' }
+  context "requests from non-superusers" do
+    it "rejects the requests" do
+      auth_header(:editor)
 
-  it "rejects requests from non-superusers" do
-    auth_header(:editor)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: "name",
+          description: "The monster's name",
+        ]
+      })
 
-    json_post(:update_model, {
-      project_name: "labors",
-      actions: [
-        action_name: "update_attribute",
-        model_name: "monster",
-        attribute_name: "name",
-        description: "The monster's name",
-      ]
-    })
-
-    expect(last_response.status).to eq(403)
+      expect(last_response.status).to eq(403)
+    end
   end
 
-  it "updates attribute options" do
-    original_attribute = Labors::Monster.attributes[:name].dup
+  context "valid and authorized request" do
+    before do
+      @original_attribute = Labors::Monster.attributes[:name].dup
+    end
 
-    auth_header(:superuser)
-    json_post(:update_model, {
-      project_name: "labors",
-      actions: [{
-        action_name: "update_attribute",
-        model_name: "monster",
-        attribute_name: proper_name,
-        description: "The monster's name",
-        display_name: "NAME"
-      }]
-    })
-    
-    expect(last_response.status).to eq(200)
-    expect(Labors::Monster.attributes[:name].description).to eq("The monster's name")
-    expect(Labors::Monster.attributes[:name].display_name).to eq("NAME")
+    after do
+      Labors::Monster.attributes[:name] = @original_attribute
+    end
 
-    response_json = JSON.parse(last_response.body)
-    attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
-    expect(attribute_json["desc"]).to eq("The monster's name")
-    expect(attribute_json["display_name"]).to eq("NAME")
+    it "returns the project template with all changes" do
+      auth_header(:superuser)
+      json_post(:update_model, {
+        project_name: "labors",
+        actions: [{
+          action_name: "update_attribute",
+          model_name: "monster",
+          attribute_name: "name",
+          description: "The monster's name",
+          display_name: "NAME"
+        }]
+      })
 
-    Labors::Monster.attributes[:name] = original_attribute
+      expect(last_response.status).to eq(200)
+
+      response_json = JSON.parse(last_response.body)
+      attribute_json = response_json["models"]["monster"]["template"]["attributes"]["name"]
+      expect(attribute_json["desc"]).to eq("The monster's name")
+      expect(attribute_json["display_name"]).to eq("NAME")
+    end
   end
 
-  describe "does not update" do
+  context "invalid action" do
     it "does not update attribute options with invalid attribute name" do
       auth_header(:superuser)
       json_post(:update_model, {
@@ -59,7 +62,7 @@ describe UpdateModelController do
         actions: [{
           action_name: "update_attribute",
           model_name: "monster",
-          attribute_name: improper_name,
+          attribute_name: "something_invalid",
           display_name: "NAME"
         }]
       })
@@ -68,83 +71,8 @@ describe UpdateModelController do
       expect(last_response.status).to eq(422)
       expect(response_json['errors'][0]['message']).to eq('Attribute does not exist')
 
-      # Other options are not changed if an update fails
+      # No other changes are made when actions fail
       expect(Labors::Monster.attributes[:name].display_name).not_to eq("NAME")
-    end
-
-    it "does not update attribute options with the invalid data type" do
-      auth_header(:superuser)
-      json_post(:update_model, {
-        project_name: "labors",
-        actions: [{
-          action_name: "update_attribute",
-          model_name: "monster",
-          attribute_name: proper_name,
-          validation: 23,
-          display_name: "NAME"
-        }]
-      })
-
-      response_json = JSON.parse(last_response.body)
-
-      expect(last_response.status).to eq(422)
-      expect(response_json['errors'][0]['message']).to eq("Update attribute failed")
-      expect(response_json['errors'][0]['reason']).to eq("validation is not properly formatted")
-
-      # Other options are not changed if an update fails
-      expect(Labors::Monster.attributes[:name].display_name).not_to eq("NAME")
-    end
-
-    it "does not update attribute_name" do
-      expected = {
-        :message=>"new_attribute_name cannot be changed", 
-        :source=>{
-          :action_name=>"update_attribute", 
-          :model_name=>"monster", 
-          :attribute_name=>"name"
-        }, 
-        :reason=>nil
-      }
-
-      auth_header(:superuser)
-      json_post(:update_model, {
-        project_name: "labors",
-        actions: [{
-          action_name: "update_attribute",
-          model_name: "monster",
-          attribute_name: proper_name,
-          new_attribute_name: 'new_name'
-        }]
-      })
-
-      expect(last_response.status).to eq(422)
-      expect(json_body[:errors][0]).to eq(expected)
-    end
-
-    it "does not update name" do
-      expected = {
-        :message=>"name cannot be changed", 
-        :source=>{
-          :action_name=>"update_attribute", 
-          :model_name=>"monster", 
-          :attribute_name=>"name"
-        }, 
-        :reason=>nil
-      }
-
-      auth_header(:superuser)
-      json_post(:update_model, {
-        project_name: "labors",
-        actions: [{
-          action_name: "update_attribute",
-          model_name: "monster",
-          attribute_name: proper_name,
-          name: 'new_name'
-        }]
-      })
-
-      expect(last_response.status).to eq(422)
-      expect(json_body[:errors][0]).to eq(expected)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -182,11 +182,7 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
-    if example.metadata[:disable_database_cleaner_transaction]
-      example.run
-    else
-      DatabaseCleaner.cleaning { example.run }
-    end
+    DatabaseCleaner.cleaning { example.run }
   end
 end
 


### PR DESCRIPTION
This PR builds on top of https://github.com/mountetna/magma/pull/181.

`Magma::AddModelAction` will add the new model and define link relationships. It makes changes to both the database and in memory so we can build and run migrations for the new model in `Magma::ModelUpdateAction`.

This PR also makes a change to `Magma::BaseAction#validate`. Before, it would stop doing validations if any action validation failed. While this might save some code cycles, it could lead to a poor user experience because users would have to make multiple requests to find all validation issues. Now `Magma::BaseAction#validate` will let all validations run so we can collect all validation problems in one request cycle. Along the same lines, `Magma::UpdateAttributeAction#validate` has been updated to do more validation checks before calling `#perform`.

Additionally, `Magma::ModelUpdateActions#perform` has been updated so it reports any unexpected errors. It was capturing these errors, but it wasn't collecting them for reporting. This would lead to an empty `errors` object in the response payload that makes debugging difficult. Now, `Magma::ModelUpdateActions#perform` will collect these errors so they get reported back to users.

Fixes #170 