### PR TITLE
Add test for TSV + collection; update collection query_to_tsv

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (4.0.3)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rspec (3.9.0)

--- a/lib/magma/attributes/collection.rb
+++ b/lib/magma/attributes/collection.rb
@@ -7,7 +7,7 @@ class Magma
     end
 
     def query_to_tsv(value)
-      query_to_payload(value).join(", ")
+      value.join(", ")
     end
 
     def revision_to_loader record, new_ids

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -176,10 +176,6 @@ describe RetrieveController do
 
   context 'collections' do
     it 'retrieves collections as a list of identifiers' do
-      # Sequel::Model returns collections as individual rows instead
-      #   of a list of entries,
-      #   so this test does not reflect the same behavior as
-      #   the code.
       project = create(:project, name: 'The Twelve Labors of Hercules')
       labors = create_list(:labor, 3, project: project)
 

--- a/spec/retrieve_spec.rb
+++ b/spec/retrieve_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 describe RetrieveController do
   include Rack::Test::Methods
 


### PR DESCRIPTION
This PR separates the Collection `payload` format from its `tsv` format. Previously the `tsv` format called `query_to_payload` internally, which caused the collection value to attempt to reformat / flatten twice, resulting in exceptions (and would result in users not being able to download TSV files in Timur, if they involved a collection attribute). This change removes the second formatting attempt and also adds a test to check behaviour.

 