### PR TITLE
Configure Magma::Attribute sti key_map

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -1,7 +1,8 @@
 class Magma
   class Attribute < Sequel::Model
     plugin :single_table_inheritance, :type,
-      model_map: Proc.new { |type| "Magma::#{type.classify}Attribute" }
+      model_map: Proc.new { |type| "Magma::#{type.classify}Attribute" },
+      key_map: Proc.new { |attribute| attribute.attribute_type }
 
     set_primary_key [:project_name, :model_name, :attribute_name]
     unrestrict_primary_key


### PR DESCRIPTION
Without a `key_map`, the Sequel single table inheritance plugin will use the `model_map` to insert values into the database. For `Magma::Attribute`, this resulted in types being inserted as Ruby classes (i.e., `Magma::IntegerAttribute`) instead of strings (i.e., `integer`). By configuring `key_map`, we can make sure `Magma::Attribute` types are inserted as strings.

Info on the plugin can be found here: http://sequel.jeremyevans.net/rdoc-plugins/classes/Sequel/Plugins/SingleTableInheritance.html.