### PR TITLE
Add rename_attribute action

### DIFF
--- a/db/migrations/006_add_column_name_to_attributes.rb
+++ b/db/migrations/006_add_column_name_to_attributes.rb
@@ -4,7 +4,9 @@ Sequel.migration do
       add_column :column_name, String
     end
 
-    Magma.instance.db.execute("UPDATE attributes SET column_name=attribute_name")
+    Magma.instance.db.execute("UPDATE attributes SET column_name=CONCAT(attribute_name,'_id') WHERE attributes.type IN ('link', 'parent')")
+
+    Magma.instance.db.execute("UPDATE attributes SET column_name=attribute_name WHERE attributes.type NOT IN ('link', 'parent')")
 
     alter_table(:attributes) do
       set_column_not_null :column_name

--- a/lib/magma/actions/add_attribute.rb
+++ b/lib/magma/actions/add_attribute.rb
@@ -8,10 +8,6 @@ class Magma
       true
     end
 
-    def rollback
-      model.attributes.delete(attribute.name)
-    end
-
     private
 
     def save_attribute

--- a/lib/magma/actions/add_model.rb
+++ b/lib/magma/actions/add_model.rb
@@ -18,11 +18,6 @@ class Magma
       true
     end
 
-    def rollback
-      parent_model.attributes.delete(@model.model_name)
-      project.unload_model(@model.model_name)
-    end
-
     private
 
     def create_model

--- a/lib/magma/actions/base_action.rb
+++ b/lib/magma/actions/base_action.rb
@@ -20,9 +20,6 @@ class Magma
       raise NotImplementedError
     end
 
-    def rollback
-    end
-
     def errors
       @errors.map(&:to_h)
     end

--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -21,7 +21,7 @@ class Magma
         true
       end
     rescue => e
-      @actions.reverse_each(&:rollback)
+      restart_server
 
       if @errors.empty?
         @errors << Magma::ActionError.new(

--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -21,7 +21,7 @@ class Magma
         true
       end
     rescue => e
-      @actions.each(&:rollback)
+      @actions.reverse_each(&:rollback)
 
       if @errors.empty?
         @errors << Magma::ActionError.new(

--- a/lib/magma/actions/model_update_actions.rb
+++ b/lib/magma/actions/model_update_actions.rb
@@ -2,6 +2,7 @@ require_relative 'base_action'
 require_relative 'update_attribute'
 require_relative 'add_attribute'
 require_relative 'add_model'
+require_relative 'rename_attribute'
 
 class Magma
   class ModelUpdateActions

--- a/lib/magma/actions/rename_attribute.rb
+++ b/lib/magma/actions/rename_attribute.rb
@@ -10,12 +10,6 @@ class Magma
       true
     end
 
-    def rollback
-      model.attributes.delete(@action_params[:new_attribute_name].to_sym)
-      attribute.attribute_name = @original_attribute_name.to_s
-      model.attributes[@original_attribute_name] = attribute
-    end
-
     private
 
     def validations

--- a/lib/magma/actions/rename_attribute.rb
+++ b/lib/magma/actions/rename_attribute.rb
@@ -1,12 +1,19 @@
 class Magma
   class RenameAttributeAction < BaseAction
     def perform
-      attribute.update(attribute_name: @action_params[:new_attribute_name])
+      @original_attribute_name = attribute.attribute_name.to_sym
 
-      model.attributes.delete(attribute.column_name.to_sym)
+      model.attributes.delete(@original_attribute_name)
+      attribute.update(attribute_name: @action_params[:new_attribute_name])
       model.attributes[attribute.attribute_name.to_sym] = attribute
 
       true
+    end
+
+    def rollback
+      model.attributes.delete(@action_params[:new_attribute_name].to_sym)
+      attribute.attribute_name = @original_attribute_name.to_s
+      model.attributes[@original_attribute_name] = attribute
     end
 
     private

--- a/lib/magma/actions/rename_attribute.rb
+++ b/lib/magma/actions/rename_attribute.rb
@@ -1,19 +1,53 @@
 class Magma
   class RenameAttributeAction < BaseAction
     def perform
-      model = Magma.instance.get_model(
-        @project_name,
-        @action_params[:model_name]
-      )
-
-      attribute = model.attributes[@action_params[:attribute_name].to_sym]
-
       attribute.update(attribute_name: @action_params[:new_attribute_name])
 
       model.attributes.delete(attribute.column_name.to_sym)
       model.attributes[attribute.attribute_name.to_sym] = attribute
 
       true
+    end
+
+    private
+
+    def validations
+      [:validate_attribute_exists, :validate_new_attribute_name]
+    end
+
+    def validate_attribute_exists
+      return if attribute
+
+      @errors << Magma::ActionError.new(
+        message: 'Attribute does not exist',
+        source: @action_params.slice(:attribute_name, :model_name)
+      )
+    end
+
+    def validate_new_attribute_name
+      return unless attribute
+      validation_attribute = attribute.dup
+      validation_attribute.set(attribute_name: @action_params[:new_attribute_name])
+
+      return if validation_attribute.valid?
+
+      validation_attribute.errors.full_messages.each do |error|
+        @errors << Magma::ActionError.new(
+          message: error,
+          source: @action_params.slice(:model_name, :new_attribute_name)
+        )
+      end
+    end
+
+    def attribute
+      @attribute ||= model.attributes[@action_params[:attribute_name].to_sym]
+    end
+
+    def model
+      @model ||= Magma.instance.get_model(
+        @project_name,
+        @action_params[:model_name]
+      )
     end
   end
 end

--- a/lib/magma/actions/rename_attribute.rb
+++ b/lib/magma/actions/rename_attribute.rb
@@ -1,0 +1,19 @@
+class Magma
+  class RenameAttributeAction < BaseAction
+    def perform
+      model = Magma.instance.get_model(
+        @project_name,
+        @action_params[:model_name]
+      )
+
+      attribute = model.attributes[@action_params[:attribute_name].to_sym]
+
+      attribute.update(attribute_name: @action_params[:new_attribute_name])
+
+      model.attributes.delete(attribute.column_name.to_sym)
+      model.attributes[attribute.attribute_name.to_sym] = attribute
+
+      true
+    end
+  end
+end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -174,6 +174,7 @@ class Magma
       super
       validate_validation_json
       validate_attribute_name_format
+      validate_attribute_name_unique
     end
 
     def validate_validation_json
@@ -186,6 +187,12 @@ class Magma
     def validate_attribute_name_format
       return if attribute_name == attribute_name&.snake_case
       errors.add(:attribute_name, "must be snake_case")
+    end
+
+    def validate_attribute_name_unique
+      return unless modified?(:attribute_name)
+      return unless @magma_model.has_attribute?(attribute_name)
+      errors.add(:attribute_name, "already exists on the model")
     end
   end
 end

--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -4,7 +4,7 @@ class Magma
       model_map: Proc.new { |type| "Magma::#{type.classify}Attribute" },
       key_map: Proc.new { |attribute| attribute.attribute_type }
 
-    set_primary_key [:project_name, :model_name, :attribute_name]
+    set_primary_key [:project_name, :model_name, :column_name]
     unrestrict_primary_key
 
     plugin :dirty

--- a/lib/magma/project.rb
+++ b/lib/magma/project.rb
@@ -65,11 +65,6 @@ class Magma
       project_container.const_set(model_data[:model_name].classify, model_class)
     end
 
-    def unload_model(model_name)
-      models.delete(model_name)
-      project_container.send(:remove_const, model_name.to_s.classify)
-    end
-
     private
 
     def project_container

--- a/spec/actions/add_attribute_actions_spec.rb
+++ b/spec/actions/add_attribute_actions_spec.rb
@@ -26,7 +26,7 @@ describe Magma::AddAttributeAction do
     context "when it succeeds" do
       after do
         # Clear out new test attributes that are cached in memory
-        action.rollback
+        Labors::Monster.attributes.delete(attribute_name.to_sym)
       end
 
       it 'adds a new attribute and returns no errors' do
@@ -130,17 +130,6 @@ describe Magma::AddAttributeAction do
         expect(action.validate).to eq(false)
         expect(action.errors.first[:message]).to eq("Attribute does not implement foo")
       end
-    end
-  end
-
-  describe "#rollback" do
-    before do
-      action.perform
-    end
-
-    it "rolls back in memory changes" do
-      action.rollback
-      expect(Labors::Monster.attributes.keys).not_to include(attribute_name.to_sym)
     end
   end
 end

--- a/spec/actions/add_model_action_spec.rb
+++ b/spec/actions/add_model_action_spec.rb
@@ -15,7 +15,10 @@ describe Magma::AddModelAction do
 
       after do
         # Remove test model and link relationships from memory
-        action.rollback
+        project = Magma.instance.get_project(:labors)
+        project.models.delete(:new_child_model)
+        Labors.send(:remove_const, :NewChildModel)
+        Labors::Labor.attributes.delete(:new_child_model)
       end
 
       it "adds the model and defines link relationships" do
@@ -54,7 +57,10 @@ describe Magma::AddModelAction do
 
       after do
         # Remove test model and link relationships from memory
-        action.rollback
+        project = Magma.instance.get_project(:labors)
+        project.models.delete(:new_table_model)
+        Labors.send(:remove_const, :NewTableModel)
+        Labors::Labor.attributes.delete(:new_table_model)
       end
 
       it "adds the model and defines link relationships" do
@@ -144,32 +150,6 @@ describe Magma::AddModelAction do
         expect(action.validate).to eq(false)
         expect(action.errors.first[:message]).to eq("parent_link_type must be one of child, collection, table")
       end
-    end
-  end
-
-  describe "#rollback" do
-    let(:action_params) do
-      {
-        action_name: "add_model",
-        model_name: "new_child_model",
-        identifier: "name",
-        parent_model_name: "labor",
-        parent_link_type: "child"
-      }
-    end
-
-    let(:project) { Magma.instance.get_project(:labors) }
-
-    before do
-      action.perform
-    end
-
-    it "rolls back in memory changes" do
-      action.rollback
-
-      expect(project.models.keys).not_to include(:new_child_model)
-      expect(Labors::Labor.attributes.keys).not_to include(:new_child_model)
-      expect { Labors::NewChildModel }.to raise_error(NameError)
     end
   end
 end

--- a/spec/actions/rename_attribute_action_spec.rb
+++ b/spec/actions/rename_attribute_action_spec.rb
@@ -84,4 +84,27 @@ describe Magma::RenameAttributeAction do
       end
     end
   end
+
+  describe "#rollback" do
+    let(:action_params) do
+      {
+        action: "rename_attribute",
+        model_name: "monster",
+        attribute_name: "species",
+        new_attribute_name: "species_name"
+      }
+    end
+
+    before do
+      action.perform
+    end
+
+    it "rolls back in memory changes" do
+      action.rollback
+
+      expect(Labors::Monster.attributes[:species_name]).to be_nil
+      expect(Labors::Monster.attributes[:species]).not_to be_nil
+      expect(Labors::Monster.attributes[:species].attribute_name).to eq("species")
+    end
+  end
 end

--- a/spec/actions/rename_attribute_action_spec.rb
+++ b/spec/actions/rename_attribute_action_spec.rb
@@ -68,6 +68,22 @@ describe Magma::RenameAttributeAction do
       end
     end
 
+    context "when the attribute is a link attribute" do
+      let(:action_params) do
+        {
+          action: "rename_attribute",
+          model_name: "monster",
+          attribute_name: "victim",
+          new_attribute_name: "victor"
+        }
+      end
+
+      it "captures an attribute error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("attribute_name doesn't match an existing model")
+      end
+    end
+
     context "when there's already an attribute with new_attribute_name" do
       let(:action_params) do
         {

--- a/spec/actions/rename_attribute_action_spec.rb
+++ b/spec/actions/rename_attribute_action_spec.rb
@@ -34,4 +34,54 @@ describe Magma::RenameAttributeAction do
       expect(renamed_attribute.validation).to eq(@original_attribute.validation)
     end
   end
+
+  describe "#validate" do
+    context "when there's no attribute with attribute_name" do
+      let(:action_params) do
+        {
+          action: "rename_attribute",
+          model_name: "monster",
+          attribute_name: "does_not_exist",
+          new_attribute_name: "species_name"
+        }
+      end
+
+      it "captures an attribute error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("Attribute does not exist")
+      end
+    end
+
+    context "when new_attribute_name is not properly formatted" do
+      let(:action_params) do
+        {
+          action: "rename_attribute",
+          model_name: "monster",
+          attribute_name: "species",
+          new_attribute_name: "speciesName"
+        }
+      end
+
+      it "captures an attribute error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("attribute_name must be snake_case")
+      end
+    end
+
+    context "when there's already an attribute with new_attribute_name" do
+      let(:action_params) do
+        {
+          action: "rename_attribute",
+          model_name: "monster",
+          attribute_name: "species",
+          new_attribute_name: "victim"
+        }
+      end
+
+      it "captures an attribute error" do
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("attribute_name already exists on the model")
+      end
+    end
+  end
 end

--- a/spec/actions/rename_attribute_action_spec.rb
+++ b/spec/actions/rename_attribute_action_spec.rb
@@ -1,0 +1,37 @@
+describe Magma::RenameAttributeAction do
+  let(:action) { Magma::RenameAttributeAction.new("labors", action_params) }
+
+  describe "#perform" do
+    let(:action_params) do
+      {
+        action: "rename_attribute",
+        model_name: "monster",
+        attribute_name: "species",
+        new_attribute_name: "species_name"
+      }
+    end
+
+    before do
+      @original_attribute = Labors::Monster.attributes[:species].dup
+    end
+
+    after do
+      # Rollback in memory changes to the attribute
+      Labors::Monster.attributes.delete(:species_name)
+      Labors::Monster.attributes[:species] = @original_attribute
+    end
+
+    it "renames the attribute" do
+      expect(action.perform).to eq(true)
+
+      expect(Labors::Monster.attributes[:species]).to be_nil
+
+      renamed_attribute = Labors::Monster.attributes[:species_name]
+      expect(renamed_attribute).not_to be_nil
+
+      expect(renamed_attribute.attribute_name).to eq("species_name")
+      expect(renamed_attribute.column_name).to eq(@original_attribute.column_name)
+      expect(renamed_attribute.validation).to eq(@original_attribute.validation)
+    end
+  end
+end

--- a/spec/actions/rename_attribute_action_spec.rb
+++ b/spec/actions/rename_attribute_action_spec.rb
@@ -84,27 +84,4 @@ describe Magma::RenameAttributeAction do
       end
     end
   end
-
-  describe "#rollback" do
-    let(:action_params) do
-      {
-        action: "rename_attribute",
-        model_name: "monster",
-        attribute_name: "species",
-        new_attribute_name: "species_name"
-      }
-    end
-
-    before do
-      action.perform
-    end
-
-    it "rolls back in memory changes" do
-      action.rollback
-
-      expect(Labors::Monster.attributes[:species_name]).to be_nil
-      expect(Labors::Monster.attributes[:species]).not_to be_nil
-      expect(Labors::Monster.attributes[:species].attribute_name).to eq("species")
-    end
-  end
 end


### PR DESCRIPTION
This PR builds off of https://github.com/mountetna/magma/pull/199. `Magma::RenameAttributeAction` will change the given attribute's `attribute_name` without changing its `column_name`.

To facilitate this change, `Magma::Attribute`'s primary key (via `Sequel::Model`) was updated so it uses  `column_name` instead of `attribute_name`.

https://github.com/mountetna/magma/blob/333cf5a0b680949272b3f042a83e4436d18b45c2/lib/magma/attribute.rb#L1-L7

`column_name` will never change so it should be treated as part of the attribute's primary key.

This PR also changes the rollback behavior in `Magma::ModelUpdateActions`. Instead of rollback actions in the order they came in, it'll roll them back in reverse so we reset things back to their original state. https://github.com/mountetna/magma/commit/333cf5a0b680949272b3f042a83e4436d18b45c2

This PR does not update model dictionaries.