### PR TITLE
Validate Magma::Attribute#type is a supported type

### DIFF
--- a/lib/magma/attribute.rb
+++ b/lib/magma/attribute.rb
@@ -169,6 +169,7 @@ class Magma
       super
       validate_validation_json
       validate_attribute_name_format
+      validate_type
     end
 
     def validate_validation_json
@@ -181,6 +182,11 @@ class Magma
     def validate_attribute_name_format
       return if attribute_name == attribute_name&.snake_case
       errors.add(:attribute_name, "must be snake_case")
+    end
+
+    def validate_type
+      return if Magma.const_defined?("#{type.classify}Attribute")
+      errors.add(:type, "is not a supported type")
     end
   end
 end

--- a/spec/magma_attribute_spec.rb
+++ b/spec/magma_attribute_spec.rb
@@ -223,4 +223,15 @@ describe Magma::Attribute do
       expect(attribute.validation_object.validate("A")).to eq(true)
     end
   end
+
+  describe "#valid?" do
+    it "returns false if type doesn't match an existing Magma::Attribute" do
+      attribute = Magma::Attribute.new(
+        attribute_name: "name",
+        type: "invalid"
+      )
+
+      expect(attribute.valid?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This validation will stop attributes from being inserted into the database via Sequel if `type` is not a supported type.

Fixes #192 